### PR TITLE
fix transaction manager race condition with graceful shutdown

### DIFF
--- a/internal/config/transaction/finitestate/configsaga.go
+++ b/internal/config/transaction/finitestate/configsaga.go
@@ -40,6 +40,14 @@ const (
 	StateError = "error" // Unrecoverable error occurred (terminal state)
 )
 
+// SagaTerminalStates defines the terminal states for the saga.
+var SagaTerminalStates = []string{
+	StateInvalid,
+	StateCompleted,
+	StateCompensated,
+	StateError,
+}
+
 // SagaTransitions defines the valid state transitions for a configuration saga.
 var SagaTransitions = map[string][]string{
 	// Initial validation flow

--- a/internal/config/transaction/transaction.go
+++ b/internal/config/transaction/transaction.go
@@ -422,20 +422,9 @@ func (tx *ConfigTransaction) GetParticipantErrors() map[string]error {
 func (tx *ConfigTransaction) WaitForCompletion(ctx context.Context) error {
 	// Check if already in a terminal state
 	currentState := tx.GetState()
-	tx.logger.Debug(
-		"WaitForCompletion called",
-		"currentState",
-		currentState,
-		"isTerminal",
-		tx.isTerminalState(currentState),
-	)
-
 	if tx.isTerminalState(currentState) {
-		tx.logger.Debug("Transaction already in terminal state, returning immediately")
 		return nil
 	}
-
-	tx.logger.Debug("Transaction not in terminal state, waiting for state changes")
 
 	// Get the FSM state channel
 	stateChan := tx.fsm.GetStateChan(ctx)
@@ -454,20 +443,9 @@ func (tx *ConfigTransaction) WaitForCompletion(ctx context.Context) error {
 			return ctx.Err()
 		case state, ok := <-stateChan:
 			if !ok {
-				// Channel closed, check final state
-				finalState := tx.GetState()
-				tx.logger.Debug("State channel closed", "finalState", finalState)
 				return nil
 			}
-			tx.logger.Debug(
-				"Received state change",
-				"newState",
-				state,
-				"isTerminal",
-				tx.isTerminalState(state),
-			)
 			if tx.isTerminalState(state) {
-				tx.logger.Debug("Transaction reached terminal state, completing wait")
 				return nil
 			}
 		}

--- a/internal/config/transaction/transaction.go
+++ b/internal/config/transaction/transaction.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 	"sync/atomic"
 	"time"
 
@@ -264,10 +265,8 @@ func (tx *ConfigTransaction) MarkCompleted() error {
 
 	tx.logger.Debug(
 		"Transaction completed successfully",
-		"state",
-		finitestate.StateCompleted,
-		"duration",
-		time.Since(tx.CreatedAt),
+		"state", finitestate.StateCompleted,
+		"duration", time.Since(tx.CreatedAt),
 	)
 	return nil
 }
@@ -423,8 +422,13 @@ func (tx *ConfigTransaction) WaitForCompletion(ctx context.Context) error {
 	// Check if already in a terminal state
 	currentState := tx.GetState()
 	if tx.isTerminalState(currentState) {
+		tx.logger.Debug("Transaction already in terminal state",
+			"currentState", currentState)
 		return nil
 	}
+
+	tx.logger.Debug("Transaction not in terminal state, waiting",
+		"currentState", currentState)
 
 	// Get the FSM state channel
 	stateChan := tx.fsm.GetStateChan(ctx)
@@ -454,20 +458,13 @@ func (tx *ConfigTransaction) WaitForCompletion(ctx context.Context) error {
 
 // isTerminalState returns true if the given state is a terminal state.
 func (tx *ConfigTransaction) isTerminalState(state string) bool {
-	switch state {
-	case finitestate.StateCompleted,
-		finitestate.StateCompensated,
-		finitestate.StateError,
-		finitestate.StateInvalid:
-		return true
-	default:
-		return false
-	}
+	return slices.Contains(finitestate.SagaTerminalStates, state)
 }
 
 // convertToAppDefinitions converts config.Apps to server app definitions
 // This adapter allows the server/apps package to work with config data
 // without directly importing the config types
+// TODO: this should be removed, and the apps should be instantiated from the domain config apps layer
 func convertToAppDefinitions(configApps apps.AppCollection) []serverApps.AppDefinition {
 	definitions := make([]serverApps.AppDefinition, 0, len(configApps))
 

--- a/internal/config/transaction/transaction_waitforcompletion_test.go
+++ b/internal/config/transaction/transaction_waitforcompletion_test.go
@@ -1,0 +1,435 @@
+package transaction
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/atlanticdynamic/firelynx/internal/config/transaction/finitestate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitForCompletion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns immediately when already in terminal state", func(t *testing.T) {
+		terminalStates := []string{
+			finitestate.StateCompleted,
+			finitestate.StateCompensated,
+			finitestate.StateError,
+			finitestate.StateInvalid,
+		}
+
+		for _, terminalState := range terminalStates {
+			t.Run(terminalState, func(t *testing.T) {
+				tx, _ := setupTest(t)
+				ctx := t.Context()
+
+				// Force transaction into terminal state
+				switch terminalState {
+				case finitestate.StateCompleted:
+					require.NoError(t, tx.BeginValidation())
+					tx.IsValid.Store(true)
+					require.NoError(t, tx.MarkValidated())
+					require.NoError(t, tx.BeginExecution())
+					require.NoError(t, tx.MarkSucceeded())
+					require.NoError(t, tx.BeginReload())
+					require.NoError(t, tx.MarkCompleted())
+				case finitestate.StateCompensated:
+					require.NoError(t, tx.BeginValidation())
+					tx.IsValid.Store(true)
+					require.NoError(t, tx.MarkValidated())
+					require.NoError(t, tx.BeginExecution())
+					require.NoError(t, tx.MarkFailed(ctx, errors.New("test error")))
+					require.NoError(t, tx.BeginCompensation())
+					require.NoError(t, tx.MarkCompensated())
+				case finitestate.StateError:
+					require.NoError(t, tx.MarkError(errors.New("test error")))
+				case finitestate.StateInvalid:
+					require.NoError(t, tx.BeginValidation())
+					require.NoError(t, tx.MarkInvalid(errors.New("validation failed")))
+				}
+
+				// WaitForCompletion should return immediately
+				start := time.Now()
+				err := tx.WaitForCompletion(ctx)
+				duration := time.Since(start)
+
+				assert.NoError(t, err)
+				assert.Less(
+					t,
+					duration,
+					10*time.Millisecond,
+					"Should return immediately for terminal state",
+				)
+				assert.Equal(t, terminalState, tx.GetState())
+			})
+		}
+	})
+
+	t.Run("waits for transaction to reach terminal state", func(t *testing.T) {
+		tx, _ := setupTest(t)
+		ctx := t.Context()
+
+		// Start transaction in non-terminal state
+		require.NoError(t, tx.BeginValidation())
+		tx.IsValid.Store(true)
+		require.NoError(t, tx.MarkValidated())
+		require.NoError(t, tx.BeginExecution())
+
+		// Start WaitForCompletion in goroutine
+		waitDone := make(chan error, 1)
+		waitStarted := make(chan struct{})
+
+		go func() {
+			close(waitStarted)
+			waitDone <- tx.WaitForCompletion(ctx)
+		}()
+
+		// Wait for goroutine to start
+		<-waitStarted
+
+		// Verify it's waiting (not completed yet)
+		select {
+		case err := <-waitDone:
+			t.Fatalf("WaitForCompletion returned too early: %v", err)
+		case <-time.After(50 * time.Millisecond):
+			// Good, it's waiting
+		}
+
+		// Complete the transaction
+		require.NoError(t, tx.MarkSucceeded())
+		require.NoError(t, tx.BeginReload())
+		require.NoError(t, tx.MarkCompleted())
+
+		// Now WaitForCompletion should return
+		assert.Eventually(t, func() bool {
+			select {
+			case err := <-waitDone:
+				assert.NoError(t, err)
+				return true
+			default:
+				return false
+			}
+		}, 1*time.Second, 10*time.Millisecond, "WaitForCompletion should return after transaction completed")
+
+		assert.Equal(t, finitestate.StateCompleted, tx.GetState())
+	})
+
+	t.Run("returns context error when context is cancelled", func(t *testing.T) {
+		tx, _ := setupTest(t)
+
+		// Start transaction in non-terminal state
+		require.NoError(t, tx.BeginValidation())
+		tx.IsValid.Store(true)
+		require.NoError(t, tx.MarkValidated())
+		require.NoError(t, tx.BeginExecution())
+
+		// Create cancellable context
+		ctx, cancel := context.WithCancel(t.Context())
+
+		// Start WaitForCompletion in goroutine
+		waitDone := make(chan error, 1)
+		waitStarted := make(chan struct{})
+
+		go func() {
+			close(waitStarted)
+			waitDone <- tx.WaitForCompletion(ctx)
+		}()
+
+		// Wait for goroutine to start
+		<-waitStarted
+
+		// Verify it's waiting
+		assert.Never(t, func() bool {
+			select {
+			case <-waitDone:
+				return true
+			default:
+				return false
+			}
+		}, 50*time.Millisecond, 10*time.Millisecond, "Should be waiting")
+
+		// Cancel context
+		cancel()
+
+		// WaitForCompletion should return with context.Canceled
+		assert.Eventually(t, func() bool {
+			select {
+			case err := <-waitDone:
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, context.Canceled)
+				return true
+			default:
+				return false
+			}
+		}, 1*time.Second, 10*time.Millisecond, "WaitForCompletion should return after context cancellation")
+	})
+
+	t.Run("returns context error when context times out", func(t *testing.T) {
+		tx, _ := setupTest(t)
+
+		// Start transaction in non-terminal state
+		require.NoError(t, tx.BeginValidation())
+		tx.IsValid.Store(true)
+		require.NoError(t, tx.MarkValidated())
+		require.NoError(t, tx.BeginExecution())
+
+		// Create context with short timeout
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		defer cancel()
+
+		// WaitForCompletion should return with context.DeadlineExceeded
+		err := tx.WaitForCompletion(ctx)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("handles multiple concurrent waiters", func(t *testing.T) {
+		tx, _ := setupTest(t)
+		ctx := t.Context()
+
+		// Start transaction in non-terminal state
+		require.NoError(t, tx.BeginValidation())
+		tx.IsValid.Store(true)
+		require.NoError(t, tx.MarkValidated())
+		require.NoError(t, tx.BeginExecution())
+
+		// Start multiple waiters
+		const numWaiters = 5
+		waitDone := make(chan error, numWaiters)
+		var wg sync.WaitGroup
+		waitersStarted := make(chan struct{})
+
+		for i := 0; i < numWaiters; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				// Signal when all waiters have started
+				if i == numWaiters-1 {
+					close(waitersStarted)
+				}
+				waitDone <- tx.WaitForCompletion(ctx)
+			}()
+		}
+
+		// Wait for all waiters to start
+		<-waitersStarted
+
+		// Ensure waiters are waiting
+		assert.Never(t, func() bool {
+			select {
+			case <-waitDone:
+				return true
+			default:
+				return false
+			}
+		}, 50*time.Millisecond, 10*time.Millisecond, "Waiters should be waiting")
+
+		// Complete the transaction
+		require.NoError(t, tx.MarkSucceeded())
+		require.NoError(t, tx.BeginReload())
+		require.NoError(t, tx.MarkCompleted())
+
+		// Wait for all waiters to complete
+		wg.Wait()
+
+		// Verify all waiters completed successfully
+		assert.Eventually(t, func() bool {
+			for i := 0; i < numWaiters; i++ {
+				select {
+				case err := <-waitDone:
+					assert.NoError(t, err, "Waiter %d should have completed successfully", i)
+				default:
+					return false
+				}
+			}
+			return true
+		}, 1*time.Second, 10*time.Millisecond, "All waiters should complete")
+	})
+
+	t.Run("works with different terminal state transitions", func(t *testing.T) {
+		testCases := []struct {
+			name          string
+			setupStates   func(*ConfigTransaction) error
+			expectedState string
+		}{
+			{
+				name: "compensation path",
+				setupStates: func(tx *ConfigTransaction) error {
+					ctx := context.Background()
+					if err := tx.BeginValidation(); err != nil {
+						return err
+					}
+					tx.IsValid.Store(true)
+					if err := tx.MarkValidated(); err != nil {
+						return err
+					}
+					if err := tx.BeginExecution(); err != nil {
+						return err
+					}
+					if err := tx.MarkFailed(ctx, errors.New("test failure")); err != nil {
+						return err
+					}
+					if err := tx.BeginCompensation(); err != nil {
+						return err
+					}
+					return tx.MarkCompensated()
+				},
+				expectedState: finitestate.StateCompensated,
+			},
+			{
+				name: "error path",
+				setupStates: func(tx *ConfigTransaction) error {
+					return tx.MarkError(errors.New("unrecoverable error"))
+				},
+				expectedState: finitestate.StateError,
+			},
+			{
+				name: "invalid path",
+				setupStates: func(tx *ConfigTransaction) error {
+					if err := tx.BeginValidation(); err != nil {
+						return err
+					}
+					return tx.MarkInvalid(errors.New("validation failed"))
+				},
+				expectedState: finitestate.StateInvalid,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				tx, _ := setupTest(t)
+				ctx := t.Context()
+
+				// Start WaitForCompletion (transaction starts in "created" state)
+
+				// Start WaitForCompletion
+				waitDone := make(chan error, 1)
+				waitStarted := make(chan struct{})
+
+				go func() {
+					close(waitStarted)
+					waitDone <- tx.WaitForCompletion(ctx)
+				}()
+
+				// Wait for goroutine to start
+				<-waitStarted
+
+				// Let waiter establish itself
+				assert.Never(t, func() bool {
+					select {
+					case <-waitDone:
+						return true
+					default:
+						return false
+					}
+				}, 20*time.Millisecond, 5*time.Millisecond, "Should be waiting")
+
+				// Transition to terminal state
+				require.NoError(t, tc.setupStates(tx))
+
+				// Verify WaitForCompletion returns
+				assert.Eventually(t, func() bool {
+					select {
+					case err := <-waitDone:
+						assert.NoError(t, err)
+						return true
+					default:
+						return false
+					}
+				}, 1*time.Second, 10*time.Millisecond, "WaitForCompletion should return after reaching terminal state")
+
+				assert.Equal(t, tc.expectedState, tx.GetState())
+			})
+		}
+	})
+
+	t.Run("handles closed state channel", func(t *testing.T) {
+		tx, _ := setupTest(t)
+		ctx := t.Context()
+
+		// Start transaction in non-terminal state
+		require.NoError(t, tx.BeginValidation())
+		tx.IsValid.Store(true)
+		require.NoError(t, tx.MarkValidated())
+		require.NoError(t, tx.BeginExecution())
+
+		// Create a context that we'll cancel to simulate channel closure
+		waitCtx, cancel := context.WithCancel(ctx)
+
+		// Start WaitForCompletion
+		waitDone := make(chan error, 1)
+		go func() {
+			waitDone <- tx.WaitForCompletion(waitCtx)
+		}()
+
+		// Cancel context after a short delay to close the state channel
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}()
+
+		// WaitForCompletion should handle the closed channel and return
+		assert.Eventually(t, func() bool {
+			select {
+			case err := <-waitDone:
+				// Should return context.Canceled error since we canceled the context
+				assert.ErrorIs(t, err, context.Canceled)
+				return true
+			default:
+				return false
+			}
+		}, 1*time.Second, 10*time.Millisecond, "WaitForCompletion should handle closed channel")
+	})
+
+	t.Run("concurrent state transitions and waiters", func(t *testing.T) {
+		tx, _ := setupTest(t)
+		ctx := t.Context()
+
+		// Start transaction in non-terminal state
+		require.NoError(t, tx.BeginValidation())
+		tx.IsValid.Store(true)
+		require.NoError(t, tx.MarkValidated())
+		require.NoError(t, tx.BeginExecution())
+
+		// Start multiple waiters and a state transition concurrently
+		const numWaiters = 3
+		waitResults := make([]error, numWaiters)
+		var wg sync.WaitGroup
+
+		// Start waiters
+		for i := 0; i < numWaiters; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				waitResults[idx] = tx.WaitForCompletion(ctx)
+			}(i)
+		}
+
+		// Start state transition after a short delay
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Let waiters start
+			time.Sleep(20 * time.Millisecond)
+
+			// Complete the transaction
+			assert.NoError(t, tx.MarkSucceeded())
+			assert.NoError(t, tx.BeginReload())
+			assert.NoError(t, tx.MarkCompleted())
+		}()
+
+		// Wait for all operations to complete
+		wg.Wait()
+
+		// Verify all waiters completed successfully
+		for i, err := range waitResults {
+			assert.NoError(t, err, "Waiter %d should have completed successfully", i)
+		}
+		assert.Equal(t, finitestate.StateCompleted, tx.GetState())
+	})
+}

--- a/internal/server/integration_tests/configupdates/saga_timing_test.go
+++ b/internal/server/integration_tests/configupdates/saga_timing_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/atlanticdynamic/firelynx/internal/config"
 	"github.com/atlanticdynamic/firelynx/internal/config/loader/toml"
 	"github.com/atlanticdynamic/firelynx/internal/config/transaction"
-	"github.com/atlanticdynamic/firelynx/internal/logging"
 	"github.com/atlanticdynamic/firelynx/internal/server/runnables/cfgservice"
 	httplistener "github.com/atlanticdynamic/firelynx/internal/server/runnables/listeners/http"
 	"github.com/atlanticdynamic/firelynx/internal/server/runnables/txmgr"
@@ -126,7 +125,6 @@ func TestSagaTimingVsHTTPServerReadiness(t *testing.T) {
 func TestHTTPRunnerRequiresInitialConfig(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
-	logging.SetupLogger("debug")
 
 	// Create transaction storage and saga orchestrator
 	txStorage := txstorage.NewMemoryStorage()

--- a/internal/server/integration_tests/configupdates/saga_timing_test.go
+++ b/internal/server/integration_tests/configupdates/saga_timing_test.go
@@ -4,6 +4,7 @@
 package configupdates
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"log/slog"
@@ -32,7 +33,8 @@ import (
 // TestSagaTimingVsHTTPServerReadiness verifies that HTTP servers are immediately
 // ready to accept connections after saga orchestrator completion.
 func TestSagaTimingVsHTTPServerReadiness(t *testing.T) {
-	ctx := t.Context()
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
 
 	// Create transaction storage and saga orchestrator
 	txStorage := txstorage.NewMemoryStorage()
@@ -122,7 +124,8 @@ func TestSagaTimingVsHTTPServerReadiness(t *testing.T) {
 // TestHTTPRunnerRequiresInitialConfig verifies that the HTTP runner waits for
 // initial configuration before transitioning to Running state
 func TestHTTPRunnerRequiresInitialConfig(t *testing.T) {
-	ctx := t.Context()
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
 	logging.SetupLogger("debug")
 
 	// Create transaction storage and saga orchestrator

--- a/internal/server/runnables/txmgr/interfaces.go
+++ b/internal/server/runnables/txmgr/interfaces.go
@@ -6,7 +6,15 @@ import (
 	"github.com/atlanticdynamic/firelynx/internal/config/transaction"
 )
 
+// SagaProcessor processes configuration transactions through the saga pattern.
 type SagaProcessor interface {
+	// ProcessTransaction processes a validated transaction through the saga lifecycle.
 	ProcessTransaction(ctx context.Context, tx *transaction.ConfigTransaction) error
+
+	// AddToStorage adds a transaction to the transaction storage.
 	AddToStorage(tx *transaction.ConfigTransaction) error
+
+	// WaitForCompletion waits for the current transaction to reach a terminal state.
+	// Returns immediately if no transaction is in progress.
+	WaitForCompletion(ctx context.Context) error
 }

--- a/internal/server/runnables/txmgr/options.go
+++ b/internal/server/runnables/txmgr/options.go
@@ -2,6 +2,7 @@ package txmgr
 
 import (
 	"log/slog"
+	"time"
 )
 
 // Option represents a functional option for configuring Runner.
@@ -26,6 +27,17 @@ func WithLogger(logger *slog.Logger) Option {
 		if logger != nil {
 			r.logger = logger
 		}
+		return nil
+	}
+}
+
+// WithSagaOrchestratorShutdownTimeout sets the timeout for shutting down the saga orchestrator.
+func WithSagaOrchestratorShutdownTimeout(timeout time.Duration) Option {
+	return func(r *Runner) error {
+		if timeout <= 0 {
+			return nil // No-op if timeout is not positive
+		}
+		r.sagaOrchestratorShutdownTimeout = timeout
 		return nil
 	}
 }

--- a/internal/server/runnables/txmgr/options_test.go
+++ b/internal/server/runnables/txmgr/options_test.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -54,4 +55,31 @@ func TestWithLogger(t *testing.T) {
 
 	// Logger should remain unchanged
 	assert.Equal(t, originalLogger, r.logger)
+}
+
+func TestWithSagaOrchestratorShutdownTimeout(t *testing.T) {
+	t.Run("positive timeout sets value", func(t *testing.T) {
+		r := &Runner{}
+		timeout := 5 * time.Second
+		opt := WithSagaOrchestratorShutdownTimeout(timeout)
+		err := opt(r)
+		assert.NoError(t, err)
+		assert.Equal(t, timeout, r.sagaOrchestratorShutdownTimeout)
+	})
+
+	t.Run("zero timeout is no-op", func(t *testing.T) {
+		r := &Runner{sagaOrchestratorShutdownTimeout: defaultSagaOrchestratorShutdownTimeout}
+		opt := WithSagaOrchestratorShutdownTimeout(0)
+		err := opt(r)
+		assert.NoError(t, err)
+		assert.Equal(t, defaultSagaOrchestratorShutdownTimeout, r.sagaOrchestratorShutdownTimeout)
+	})
+
+	t.Run("negative timeout is no-op", func(t *testing.T) {
+		r := &Runner{sagaOrchestratorShutdownTimeout: defaultSagaOrchestratorShutdownTimeout}
+		opt := WithSagaOrchestratorShutdownTimeout(-1 * time.Second)
+		err := opt(r)
+		assert.NoError(t, err)
+		assert.Equal(t, defaultSagaOrchestratorShutdownTimeout, r.sagaOrchestratorShutdownTimeout)
+	})
 }

--- a/internal/server/runnables/txmgr/orchestrator/saga.go
+++ b/internal/server/runnables/txmgr/orchestrator/saga.go
@@ -381,17 +381,9 @@ func (o *SagaOrchestrator) WaitForCompletion(ctx context.Context) error {
 	o.mutex.RUnlock()
 
 	if currentTx == nil {
-		o.logger.Debug("No current transaction to wait for")
 		return nil
 	}
 
-	o.logger.Debug(
-		"Waiting for current transaction to complete",
-		"txID",
-		currentTx.ID,
-		"currentState",
-		currentTx.GetState(),
-	)
 	return currentTx.WaitForCompletion(ctx)
 }
 

--- a/internal/server/runnables/txmgr/orchestrator/saga.go
+++ b/internal/server/runnables/txmgr/orchestrator/saga.go
@@ -381,9 +381,13 @@ func (o *SagaOrchestrator) WaitForCompletion(ctx context.Context) error {
 	o.mutex.RUnlock()
 
 	if currentTx == nil {
+		o.logger.Debug("No current transaction to wait for")
 		return nil
 	}
 
+	o.logger.Debug("Current transaction found, waiting for completion",
+		"txID", currentTx.ID,
+		"currentState", currentTx.GetState())
 	return currentTx.WaitForCompletion(ctx)
 }
 

--- a/internal/server/runnables/txmgr/orchestrator/saga.go
+++ b/internal/server/runnables/txmgr/orchestrator/saga.go
@@ -373,6 +373,28 @@ func (o *SagaOrchestrator) AddToStorage(tx *transaction.ConfigTransaction) error
 	return o.txStorage.Add(tx)
 }
 
+// WaitForCompletion waits for the current transaction to reach a terminal state.
+// Returns immediately if no transaction is in progress.
+func (o *SagaOrchestrator) WaitForCompletion(ctx context.Context) error {
+	o.mutex.RLock()
+	currentTx := o.txStorage.GetCurrent()
+	o.mutex.RUnlock()
+
+	if currentTx == nil {
+		o.logger.Debug("No current transaction to wait for")
+		return nil
+	}
+
+	o.logger.Debug(
+		"Waiting for current transaction to complete",
+		"txID",
+		currentTx.ID,
+		"currentState",
+		currentTx.GetState(),
+	)
+	return currentTx.WaitForCompletion(ctx)
+}
+
 // TriggerReload initiates a synchronous reload of all participants in the saga.
 // This is called after a transaction has successfully completed execution
 // (reaches the succeeded state).
@@ -398,16 +420,22 @@ func (o *SagaOrchestrator) TriggerReload(ctx context.Context) error {
 		return nil
 	}
 
-	// Only reload if we have participants registered
-	if len(participants) == 0 {
-		logger.Debug("No participants registered for reload")
-		return nil
-	}
-
 	// Mark transaction as reloading
 	if err := currentTx.BeginReload(); err != nil {
 		logger.Error("Failed to mark transaction as reloading", "error", err)
 		return err
+	}
+
+	// If no participants are registered, we can complete immediately
+	if len(participants) == 0 {
+		logger.Debug("No participants registered for reload")
+		// Mark as completed since there's nothing to reload
+		if err := currentTx.MarkCompleted(); err != nil {
+			logger.Error("Failed to mark transaction as completed (no participants)", "error", err)
+			return err
+		}
+		logger.Debug("Transaction completed successfully (no participants)")
+		return nil
 	}
 
 	// Get sorted participant names for deterministic ordering

--- a/internal/server/runnables/txmgr/runner.go
+++ b/internal/server/runnables/txmgr/runner.go
@@ -164,15 +164,13 @@ func (r *Runner) shutdown(ctx context.Context) error {
 	}
 
 	// Wait for current transaction to complete before shutting down
-	if r.ctx != nil {
-		logger.Debug("Starting graceful shutdown wait for transaction completion")
+	logger.Debug("Starting graceful shutdown wait for transaction completion")
 
-		if err := r.sagaOrchestrator.WaitForCompletion(ctx); err != nil {
-			logger.Error("Failed to wait for transaction completion during shutdown", "error", err)
-			return err
-		}
-		logger.Debug("Transaction completion wait finished successfully")
+	if err := r.sagaOrchestrator.WaitForCompletion(ctx); err != nil {
+		logger.Error("Failed to wait for transaction completion during shutdown", "error", err)
+		return err
 	}
+	logger.Debug("Transaction completion wait finished successfully")
 
 	if err := r.fsm.Transition(finitestate.StatusStopped); err != nil {
 		logger.Error("Failed to transition to stopped", "error", err)

--- a/internal/server/runnables/txmgr/runner.go
+++ b/internal/server/runnables/txmgr/runner.go
@@ -22,8 +22,8 @@ import (
 )
 
 const (
-	// shutdownTimeout is the maximum time to wait for transactions to complete during shutdown
-	shutdownTimeout = 2 * time.Minute
+	// defaultSagaOrchestratorShutdownTimeout is the maximum time to wait for transactions to complete during shutdown
+	defaultSagaOrchestratorShutdownTimeout = 2 * time.Minute
 )
 
 // Interface guards
@@ -39,7 +39,8 @@ type Runner struct {
 	txSiphon chan *transaction.ConfigTransaction
 
 	// Saga orchestrator for processing
-	sagaOrchestrator SagaProcessor
+	sagaOrchestrator                SagaProcessor
+	sagaOrchestratorShutdownTimeout time.Duration
 
 	// State management
 	fsm finitestate.Machine
@@ -62,8 +63,9 @@ func NewRunner(
 	}
 
 	r := &Runner{
-		sagaOrchestrator: sagaOrchestrator,
-		logger:           slog.Default().WithGroup("txmgr.Runner"),
+		sagaOrchestrator:                sagaOrchestrator,
+		sagaOrchestratorShutdownTimeout: defaultSagaOrchestratorShutdownTimeout,
+		logger:                          slog.Default().WithGroup("txmgr.Runner"),
 		// this should almost always be unbuffered
 		txSiphon: make(chan *transaction.ConfigTransaction),
 	}
@@ -118,19 +120,11 @@ func (r *Runner) Run(ctx context.Context) error {
 		select {
 		case <-runCtx.Done():
 			logger.Debug("Run context cancelled")
-
-			// Create fresh context for graceful shutdown since runCtx is canceled
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
-			defer cancel()
-			return r.shutdown(shutdownCtx) //nolint:contextcheck
+			return r.shutdown() //nolint:contextcheck
 		case tx, ok := <-r.txSiphon:
 			if !ok {
 				logger.Debug("Transaction siphon closed")
-
-				// Create fresh context for graceful shutdown since runCtx is canceled
-				shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
-				defer cancel()
-				return r.shutdown(shutdownCtx) //nolint:contextcheck
+				return r.shutdown() //nolint:contextcheck
 			}
 			logger.Debug("Received transaction", "id", tx.ID)
 			if err := r.processTransaction(runCtx, tx); err != nil {
@@ -155,9 +149,13 @@ func (r *Runner) Stop() {
 }
 
 // shutdown performs graceful shutdown of the transaction manager.
-func (r *Runner) shutdown(ctx context.Context) error {
+func (r *Runner) shutdown() error {
 	logger := r.logger.WithGroup("shutdown")
 	logger.Debug("Transaction manager shutting down")
+
+	// Create fresh context for graceful shutdown since runCtx is canceled
+	ctx, cancel := context.WithTimeout(context.Background(), r.sagaOrchestratorShutdownTimeout)
+	defer cancel()
 
 	if err := r.fsm.Transition(finitestate.StatusStopping); err != nil {
 		logger.Error("Failed to transition to stopping", "error", err)
@@ -166,11 +164,15 @@ func (r *Runner) shutdown(ctx context.Context) error {
 	// Wait for current transaction to complete before shutting down
 	logger.Debug("Starting graceful shutdown wait for transaction completion")
 
+	waitStart := time.Now()
 	if err := r.sagaOrchestrator.WaitForCompletion(ctx); err != nil {
-		logger.Error("Failed to wait for transaction completion during shutdown", "error", err)
+		logger.Error("Failed to wait for transaction completion during shutdown",
+			"error", err,
+			"waitDuration", time.Since(waitStart))
 		return err
 	}
-	logger.Debug("Transaction completion wait finished successfully")
+	logger.Debug("Transaction completion wait finished successfully",
+		"waitDuration", time.Since(waitStart))
 
 	if err := r.fsm.Transition(finitestate.StatusStopped); err != nil {
 		logger.Error("Failed to transition to stopped", "error", err)

--- a/internal/server/runnables/txmgr/runner_context_test.go
+++ b/internal/server/runnables/txmgr/runner_context_test.go
@@ -159,3 +159,7 @@ func (e *errorReturningOrchestrator) ProcessTransaction(
 ) error {
 	return errors.New("saga processing failed: context canceled")
 }
+
+func (e *errorReturningOrchestrator) WaitForCompletion(ctx context.Context) error {
+	return nil
+}

--- a/internal/server/runnables/txmgr/runner_saga_test.go
+++ b/internal/server/runnables/txmgr/runner_saga_test.go
@@ -1,0 +1,152 @@
+package txmgr
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/atlanticdynamic/firelynx/internal/config/transaction"
+	"github.com/atlanticdynamic/firelynx/internal/server/runnables/txmgr/txstorage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockSagaProcessor is a test implementation of SagaProcessor
+type mockSagaProcessor struct {
+	tb               testing.TB
+	txStorage        *txstorage.MemoryStorage
+	waitDuration     time.Duration
+	waitForCompleted chan struct{}
+}
+
+func newMockSagaProcessor(
+	tb testing.TB,
+	txStorage *txstorage.MemoryStorage,
+	waitDuration time.Duration,
+) *mockSagaProcessor {
+	tb.Helper()
+	return &mockSagaProcessor{
+		tb:               tb,
+		txStorage:        txStorage,
+		waitDuration:     waitDuration,
+		waitForCompleted: make(chan struct{}),
+	}
+}
+
+func (m *mockSagaProcessor) ProcessTransaction(
+	ctx context.Context,
+	tx *transaction.ConfigTransaction,
+) error {
+	m.tb.Helper()
+	if err := tx.MarkCommitted(); err != nil {
+		return err
+	}
+	m.txStorage.SetCurrent(tx)
+	return nil
+}
+
+func (m *mockSagaProcessor) AddToStorage(tx *transaction.ConfigTransaction) error {
+	m.tb.Helper()
+	err := m.txStorage.Add(tx)
+	require.NoError(m.tb, err, "failed to add transaction to storage")
+	return nil
+}
+
+func (m *mockSagaProcessor) WaitForCompletion(ctx context.Context) error {
+	m.tb.Helper()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(m.waitDuration):
+		close(m.waitForCompleted)
+		return nil
+	}
+}
+
+func TestRunnerShutdownTimeout(t *testing.T) {
+	t.Run("shutdown respects custom timeout", func(t *testing.T) {
+		txStorage := txstorage.NewMemoryStorage()
+		// Create a mock that waits 2 seconds
+		mockSaga := newMockSagaProcessor(t, txStorage, 2*time.Second)
+
+		// Create runner with 100ms timeout
+		runner, err := NewRunner(
+			mockSaga,
+			WithSagaOrchestratorShutdownTimeout(100*time.Millisecond),
+		)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- runner.Run(ctx)
+		}()
+
+		// Wait for runner to start
+		assert.Eventually(t, func() bool {
+			return runner.IsRunning()
+		}, 5*time.Second, 10*time.Millisecond)
+
+		// Cancel context to trigger shutdown
+		cancel()
+
+		// Assert that WaitForCompletion was NOT completed within 1 second
+		assert.Never(t, func() bool {
+			select {
+			case <-mockSaga.waitForCompleted:
+				return true
+			default:
+				return false
+			}
+		}, 1*time.Second, 10*time.Millisecond, "WaitForCompletion should not complete due to timeout")
+
+		// Verify shutdown completed with timeout error
+		select {
+		case err := <-errCh:
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "context deadline exceeded")
+		case <-time.After(1 * time.Second):
+			t.Fatal("Runner did not complete within expected time")
+		}
+	})
+
+	t.Run("shutdown completes when saga finishes quickly", func(t *testing.T) {
+		txStorage := txstorage.NewMemoryStorage()
+		// Create a mock that completes immediately
+		mockSaga := newMockSagaProcessor(t, txStorage, 0)
+
+		// Create runner with default timeout
+		runner, err := NewRunner(mockSaga)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- runner.Run(ctx)
+		}()
+
+		// Wait for runner to start
+		assert.Eventually(t, func() bool {
+			return runner.IsRunning()
+		}, 5*time.Second, 10*time.Millisecond)
+
+		// Cancel context to trigger shutdown
+		cancel()
+
+		// Verify shutdown completed successfully
+		select {
+		case err := <-errCh:
+			assert.NoError(t, err)
+		case <-time.After(1 * time.Second):
+			t.Fatal("Runner did not complete within expected time")
+		}
+
+		// Verify WaitForCompletion was completed
+		select {
+		case <-mockSaga.waitForCompleted:
+			// Success
+		default:
+			t.Fatal("WaitForCompletion should have completed")
+		}
+	})
+}

--- a/internal/server/runnables/txmgr/runner_test.go
+++ b/internal/server/runnables/txmgr/runner_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/atlanticdynamic/firelynx/internal/config"
 	"github.com/atlanticdynamic/firelynx/internal/config/transaction"
+	"github.com/atlanticdynamic/firelynx/internal/logging"
 	"github.com/atlanticdynamic/firelynx/internal/server/finitestate"
 	"github.com/atlanticdynamic/firelynx/internal/server/runnables/txmgr/orchestrator"
 	"github.com/atlanticdynamic/firelynx/internal/server/runnables/txmgr/txstorage"
@@ -126,6 +127,9 @@ func TestRunnerOptionsFull(t *testing.T) {
 }
 
 func TestRunnerReceivesConfig(t *testing.T) {
+	// Enable debug logging to see what's happening
+	logging.SetupLogger("debug")
+
 	h := newTestHarness(t)
 	h.start()
 

--- a/internal/server/runnables/txmgr/runner_test.go
+++ b/internal/server/runnables/txmgr/runner_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/atlanticdynamic/firelynx/internal/config"
 	"github.com/atlanticdynamic/firelynx/internal/config/transaction"
-	"github.com/atlanticdynamic/firelynx/internal/logging"
 	"github.com/atlanticdynamic/firelynx/internal/server/finitestate"
 	"github.com/atlanticdynamic/firelynx/internal/server/runnables/txmgr/orchestrator"
 	"github.com/atlanticdynamic/firelynx/internal/server/runnables/txmgr/txstorage"
@@ -127,9 +126,6 @@ func TestRunnerOptionsFull(t *testing.T) {
 }
 
 func TestRunnerReceivesConfig(t *testing.T) {
-	// Enable debug logging to see what's happening
-	logging.SetupLogger("debug")
-
 	h := newTestHarness(t)
 	h.start()
 

--- a/internal/server/runnables/txmgr/runner_test.go
+++ b/internal/server/runnables/txmgr/runner_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/atlanticdynamic/firelynx/internal/config"
 	"github.com/atlanticdynamic/firelynx/internal/config/transaction"
+	"github.com/atlanticdynamic/firelynx/internal/logging"
 	"github.com/atlanticdynamic/firelynx/internal/server/finitestate"
 	"github.com/atlanticdynamic/firelynx/internal/server/runnables/txmgr/orchestrator"
 	"github.com/atlanticdynamic/firelynx/internal/server/runnables/txmgr/txstorage"
@@ -126,7 +127,8 @@ func TestRunnerOptionsFull(t *testing.T) {
 }
 
 func TestRunnerReceivesConfig(t *testing.T) {
-	h := newTestHarness(t)
+	handler := logging.SetupHandler("debug")
+	h := newTestHarness(t, WithLogHandler(handler))
 	h.start()
 
 	// Send config transaction

--- a/internal/server/runnables/txmgr/runner_test.go
+++ b/internal/server/runnables/txmgr/runner_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/atlanticdynamic/firelynx/internal/config"
 	"github.com/atlanticdynamic/firelynx/internal/config/transaction"
-	"github.com/atlanticdynamic/firelynx/internal/logging"
 	"github.com/atlanticdynamic/firelynx/internal/server/finitestate"
 	"github.com/atlanticdynamic/firelynx/internal/server/runnables/txmgr/orchestrator"
 	"github.com/atlanticdynamic/firelynx/internal/server/runnables/txmgr/txstorage"
@@ -127,8 +126,7 @@ func TestRunnerOptionsFull(t *testing.T) {
 }
 
 func TestRunnerReceivesConfig(t *testing.T) {
-	handler := logging.SetupHandler("debug")
-	h := newTestHarness(t, WithLogHandler(handler))
+	h := newTestHarness(t)
 	h.start()
 
 	// Send config transaction


### PR DESCRIPTION
Previously there were flaky test failures in CI where `TestSagaTimingVsHTTPServerReadiness` would fail with "connection refused" errors. This was caused by a race condition between test context cancellation and configuration reload operations where transactions with zero "participants" would get stuck in "succeeded" state instead of transitioning to "completed".

So, this change fixes the FSM state transition bug in `TriggerReload` and implements graceful shutdown in the transaction manager that waits for active transactions to complete before shutting down, preventing interrupted reload operations that could leave HTTP servers in an unready state.