### PR TITLE
add logging presets, and external log file support

### DIFF
--- a/examples/config/logging-full.toml
+++ b/examples/config/logging-full.toml
@@ -1,0 +1,106 @@
+# FireLynx Configuration Example: Full Manual Logging Configuration
+#
+# This configuration demonstrates the complete manual setup of console logging
+# middleware without using presets. This shows all available configuration options
+# for fine-grained control over logging behavior.
+#
+# NOTE: For most use cases, consider using the preset-based configurations:
+# - logging-minimal.toml (minimal preset)
+# - logging-presets.toml (multiple presets with file output)
+#
+# Features demonstrated:
+# - Manual field selection without presets
+# - Detailed request/response configuration
+# - Path and method filtering
+# - Complete control over all logging options
+
+version = "v1"
+
+# HTTP Listener Configuration
+# Listens on port 8080 with 30-second read/write timeouts
+[[listeners]]
+id = "http"
+address = ":8080"         # Listen on all interfaces, port 8080
+type = "http"             # HTTP protocol listener
+
+[listeners.http]
+read_timeout = "30s"      # Maximum time to read the entire request
+write_timeout = "30s"     # Maximum time to write the response
+
+# Endpoint Configuration
+# Connects the HTTP listener to routes and middleware
+[[endpoints]]
+id = "main"
+listener_id = "http"      # References the listener defined above
+
+# Console Logger Middleware Configuration
+# Logs HTTP requests and responses to console in JSON format
+[[endpoints.middlewares]]
+id = "request-logger"
+type = "console_logger"   # Built-in console logging middleware
+
+[endpoints.middlewares.console_logger]
+
+# Logging Output Options
+[endpoints.middlewares.console_logger.options]
+format = "json"           # Output format: "json" or "text"
+level = "info"            # Log level: "debug", "info", "warn", "error"
+
+# HTTP Field Selection
+# Control which HTTP fields are included in log entries
+[endpoints.middlewares.console_logger.fields]
+method = true             # Include HTTP method (GET, POST, etc.)
+path = true               # Include request path
+client_ip = true          # Include client IP address
+query_params = false      # Exclude query parameters for privacy
+protocol = false          # Exclude HTTP protocol version
+host = false              # Exclude Host header
+scheme = false            # Exclude URL scheme (http/https)
+status_code = true        # Include HTTP response status code
+duration = true           # Include request processing duration
+
+# Request Body Logging
+# Configure logging of request bodies and headers
+[endpoints.middlewares.console_logger.fields.request]
+enabled = true            # Enable request logging
+body = false              # Don't log request body for privacy/size
+max_body_size = 0         # Maximum body size to log (0 = disabled)
+body_size = false         # Don't log size of request body
+headers = false           # Don't log request headers for privacy
+include_headers = []      # Specific headers to include (if headers = true)
+exclude_headers = []      # Specific headers to exclude
+
+# Response Body Logging  
+# Configure logging of response bodies and headers
+[endpoints.middlewares.console_logger.fields.response]
+enabled = true            # Enable response logging
+body = false              # Don't log response body for size/privacy
+max_body_size = 0         # Maximum body size to log (0 = disabled)
+body_size = false         # Don't log size of response body
+headers = false           # Don't log response headers
+include_headers = []      # Specific headers to include (if headers = true)
+exclude_headers = []      # Specific headers to exclude
+
+# Path-Based Filtering
+# Control which request paths should be logged
+include_only_paths = []           # If non-empty, only log these paths
+exclude_paths = ["/health", "/metrics"]  # Skip logging for these paths
+
+# HTTP Method Filtering
+# Control which HTTP methods should be logged
+include_only_methods = []         # If non-empty, only log these methods
+exclude_methods = ["OPTIONS"]    # Skip logging for these methods
+
+# Route Configuration
+# Defines how requests are routed to backend applications
+[[endpoints.routes]]
+app_id = "greetz"           # Route all requests to the "greetz" app
+[endpoints.routes.http]
+path_prefix = "/"         # Match all paths starting with "/"
+
+# Application Definition
+# Simple echo app that returns a greeting message
+[[apps]]
+id = "greetz"
+[apps.echo]
+response = "Hello, World!"  # Static response for all requests

--- a/examples/config/logging-minimal.toml
+++ b/examples/config/logging-minimal.toml
@@ -1,0 +1,45 @@
+# FireLynx Configuration Example: Minimal Logging Setup
+#
+# This configuration demonstrates the simplest possible logging setup
+# using the new preset system to reduce configuration verbosity.
+#
+# Compare this with the original logging.toml which required 50+ lines
+# of configuration - this achieves similar functionality in just a few lines.
+
+version = "v1"
+
+# HTTP Listener Configuration
+[[listeners]]
+id = "http"
+address = ":8080"
+type = "http"
+
+[listeners.http]
+read_timeout = "30s"
+write_timeout = "30s"
+
+# Endpoint Configuration with Minimal Logger
+[[endpoints]]
+id = "main"
+listener_id = "http"
+
+# Minimal Logger Setup - just method, path, and status code
+[[endpoints.middlewares]]
+id = "logger"
+type = "console_logger"
+
+[endpoints.middlewares.console_logger]
+preset = "minimal"   # Only logs method, path, status_code
+output = "stdout"    # Default output
+
+# Route Configuration
+[[endpoints.routes]]
+app_id = "hello"
+[endpoints.routes.http]
+path_prefix = "/"
+
+# Application Definition
+[[apps]]
+id = "hello"
+[apps.echo]
+response = "Hello, World!"

--- a/examples/config/logging-presets.toml
+++ b/examples/config/logging-presets.toml
@@ -1,0 +1,53 @@
+# FireLynx Configuration Example: Logger Presets and Output Destinations
+#
+# This configuration demonstrates the new preset-based logging system and
+# configurable output destinations with environment variable interpolation.
+#
+# Features demonstrated:
+# - Using preset configurations for common logging scenarios
+# - File output with environment variable interpolation
+# - Multiple logger instances with different destinations
+# - Simplified configuration using presets
+
+version = "v1"
+
+# HTTP Listener Configuration
+[[listeners]]
+id = "http"
+address = ":8080"
+type = "http"
+
+[listeners.http]
+read_timeout = "30s"
+write_timeout = "30s"
+
+# Endpoint Configuration with Multiple Loggers
+[[endpoints]]
+id = "main"
+listener_id = "http"
+
+# File Logger with Detailed Preset and Environment Variable Interpolation
+[[endpoints.middlewares]]
+id = "file-logger"
+type = "console_logger"
+
+[endpoints.middlewares.console_logger]
+preset = "detailed"                              # Includes headers, query params, etc.
+output = "/tmp/firelynx-${HOSTNAME}.log"         # Environment variable interpolation
+exclude_paths = ["/health", "/metrics"]         # Skip health checks
+
+[endpoints.middlewares.console_logger.options]
+format = "json"
+level = "debug"
+
+# Route Configuration
+[[endpoints.routes]]
+app_id = "hello"
+[endpoints.routes.http]
+path_prefix = "/"
+
+# Application Definition
+[[apps]]
+id = "hello"
+[apps.echo]
+response = "Hello from FireLynx with Enhanced Logging!"

--- a/examples/config/logging-presets.toml
+++ b/examples/config/logging-presets.toml
@@ -1,13 +1,18 @@
 # FireLynx Configuration Example: Logger Presets and Output Destinations
 #
 # This configuration demonstrates the new preset-based logging system and
-# configurable output destinations with environment variable interpolation.
+# configurable output destinations.
 #
 # Features demonstrated:
 # - Using preset configurations for common logging scenarios
-# - File output with environment variable interpolation
-# - Multiple logger instances with different destinations
+# - File output destinations
+# - Path filtering with exclude patterns
 # - Simplified configuration using presets
+#
+# Environment Variable Support:
+# The output field supports environment variable interpolation using ${VAR_NAME} syntax.
+# Example: output = "/var/log/app-${HOSTNAME}.log"
+# If HOSTNAME is not set, configuration loading will fail with a clear error message.
 
 version = "v1"
 
@@ -33,7 +38,7 @@ type = "console_logger"
 
 [endpoints.middlewares.console_logger]
 preset = "detailed"                              # Includes headers, query params, etc.
-output = "/tmp/firelynx-${HOSTNAME}.log"         # Environment variable interpolation
+output = "/tmp/firelynx-server.log"              # File output destination
 exclude_paths = ["/health", "/metrics"]         # Skip health checks
 
 [endpoints.middlewares.console_logger.options]

--- a/examples/config/logging.toml
+++ b/examples/config/logging.toml
@@ -1,101 +1,50 @@
-# FireLynx Configuration Example: Console Logging
+# FireLynx Configuration Example: Preset-Based Logging
 #
-# This configuration demonstrates how to set up console logging middleware
-# to capture and log HTTP request/response details in JSON format.
+# This configuration demonstrates the preset-based logging system
+# for common logging scenarios with minimal configuration.
 #
-# Features demonstrated:
-# - HTTP listener with timeouts
-# - Console logger middleware with selective field logging
-# - Path and method filtering to exclude unwanted requests
-# - Echo app for testing the logging functionality
+# Compare this setup with logging-full.toml which shows manual field configuration.
+# This example uses presets to achieve similar functionality with fewer lines.
 
 version = "v1"
 
 # HTTP Listener Configuration
-# Listens on port 8080 with 30-second read/write timeouts
 [[listeners]]
 id = "http"
-address = ":8080"         # Listen on all interfaces, port 8080
-type = "http"             # HTTP protocol listener
+address = ":8080"
+type = "http"
 
 [listeners.http]
-read_timeout = "30s"      # Maximum time to read the entire request
-write_timeout = "30s"     # Maximum time to write the response
+read_timeout = "30s"
+write_timeout = "30s"
 
 # Endpoint Configuration
-# Connects the HTTP listener to routes and middleware
 [[endpoints]]
 id = "main"
-listener_id = "http"      # References the listener defined above
+listener_id = "http"
 
-# Console Logger Middleware Configuration
-# Logs HTTP requests and responses to console in JSON format
+# Standard Logger Setup - includes method, path, status, client IP, and duration
 [[endpoints.middlewares]]
-id = "request-logger"
-type = "console_logger"   # Built-in console logging middleware
+id = "logger"
+type = "console_logger"
 
 [endpoints.middlewares.console_logger]
+preset = "standard"                           # Includes method, path, status, client IP, duration
+output = "stdout"                             # Can be "stderr" or file path like "/tmp/app.log"
+exclude_paths = ["/health", "/metrics"]      # Skip health checks
 
-# Logging Output Options
 [endpoints.middlewares.console_logger.options]
-format = "json"           # Output format: "json" or "text"
-level = "info"            # Log level: "debug", "info", "warn", "error"
-
-# HTTP Field Selection
-# Control which HTTP fields are included in log entries
-[endpoints.middlewares.console_logger.fields]
-method = true             # Include HTTP method (GET, POST, etc.)
-path = true               # Include request path
-client_ip = true          # Include client IP address
-query_params = false      # Exclude query parameters for privacy
-protocol = false          # Exclude HTTP protocol version
-host = false              # Exclude Host header
-scheme = false            # Exclude URL scheme (http/https)
-status_code = true        # Include HTTP response status code
-duration = true           # Include request processing duration
-
-# Request Body Logging
-# Configure logging of request bodies and headers
-[endpoints.middlewares.console_logger.fields.request]
-enabled = true            # Enable request logging
-body = false              # Don't log request body for privacy/size
-max_body_size = 0         # Maximum body size to log (0 = disabled)
-body_size = false         # Don't log size of request body
-headers = false           # Don't log request headers for privacy
-include_headers = []      # Specific headers to include (if headers = true)
-exclude_headers = []      # Specific headers to exclude
-
-# Response Body Logging  
-# Configure logging of response bodies and headers
-[endpoints.middlewares.console_logger.fields.response]
-enabled = true            # Enable response logging
-body = false              # Don't log response body for size/privacy
-max_body_size = 0         # Maximum body size to log (0 = disabled)
-body_size = false         # Don't log size of response body
-headers = false           # Don't log response headers
-include_headers = []      # Specific headers to include (if headers = true)
-exclude_headers = []      # Specific headers to exclude
-
-# Path-Based Filtering
-# Control which request paths should be logged
-include_only_paths = []           # If non-empty, only log these paths
-exclude_paths = ["/health", "/metrics"]  # Skip logging for these paths
-
-# HTTP Method Filtering
-# Control which HTTP methods should be logged
-include_only_methods = []         # If non-empty, only log these methods
-exclude_methods = ["OPTIONS"]    # Skip logging for these methods
+format = "json"
+level = "info"
 
 # Route Configuration
-# Defines how requests are routed to backend applications
 [[endpoints.routes]]
-app_id = "greetz"           # Route all requests to the "greetz" app
+app_id = "hello"
 [endpoints.routes.http]
-path_prefix = "/"         # Match all paths starting with "/"
+path_prefix = "/"
 
 # Application Definition
-# Simple echo app that returns a greeting message
 [[apps]]
-id = "greetz"
+id = "hello"
 [apps.echo]
-response = "Hello, World!"  # Static response for all requests
+response = "Hello from FireLynx!"

--- a/gen/settings/v1alpha1/middleware/v1/logger.pb.go
+++ b/gen/settings/v1alpha1/middleware/v1/logger.pb.go
@@ -21,6 +21,62 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// Preset configurations for common logging scenarios
+type LogPreset int32
+
+const (
+	LogPreset_PRESET_UNSPECIFIED LogPreset = 0
+	LogPreset_PRESET_MINIMAL     LogPreset = 1 // Only method, path, status code
+	LogPreset_PRESET_STANDARD    LogPreset = 2 // Minimal + client IP, duration
+	LogPreset_PRESET_DETAILED    LogPreset = 3 // Standard + headers, query params
+	LogPreset_PRESET_DEBUG       LogPreset = 4 // Everything including request/response bodies
+)
+
+// Enum value maps for LogPreset.
+var (
+	LogPreset_name = map[int32]string{
+		0: "PRESET_UNSPECIFIED",
+		1: "PRESET_MINIMAL",
+		2: "PRESET_STANDARD",
+		3: "PRESET_DETAILED",
+		4: "PRESET_DEBUG",
+	}
+	LogPreset_value = map[string]int32{
+		"PRESET_UNSPECIFIED": 0,
+		"PRESET_MINIMAL":     1,
+		"PRESET_STANDARD":    2,
+		"PRESET_DETAILED":    3,
+		"PRESET_DEBUG":       4,
+	}
+)
+
+func (x LogPreset) Enum() *LogPreset {
+	p := new(LogPreset)
+	*p = x
+	return p
+}
+
+func (x LogPreset) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (LogPreset) Descriptor() protoreflect.EnumDescriptor {
+	return file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[0].Descriptor()
+}
+
+func (LogPreset) Type() protoreflect.EnumType {
+	return &file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[0]
+}
+
+func (x LogPreset) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use LogPreset.Descriptor instead.
+func (LogPreset) EnumDescriptor() ([]byte, []int) {
+	return file_settings_v1alpha1_middleware_v1_logger_proto_rawDescGZIP(), []int{0}
+}
+
 type LogOptionsGeneral_Format int32
 
 const (
@@ -54,11 +110,11 @@ func (x LogOptionsGeneral_Format) String() string {
 }
 
 func (LogOptionsGeneral_Format) Descriptor() protoreflect.EnumDescriptor {
-	return file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[0].Descriptor()
+	return file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[1].Descriptor()
 }
 
 func (LogOptionsGeneral_Format) Type() protoreflect.EnumType {
-	return &file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[0]
+	return &file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[1]
 }
 
 func (x LogOptionsGeneral_Format) Number() protoreflect.EnumNumber {
@@ -112,11 +168,11 @@ func (x LogOptionsGeneral_Level) String() string {
 }
 
 func (LogOptionsGeneral_Level) Descriptor() protoreflect.EnumDescriptor {
-	return file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[1].Descriptor()
+	return file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[2].Descriptor()
 }
 
 func (LogOptionsGeneral_Level) Type() protoreflect.EnumType {
-	return &file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[1]
+	return &file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[2]
 }
 
 func (x LogOptionsGeneral_Level) Number() protoreflect.EnumNumber {
@@ -325,15 +381,26 @@ type ConsoleLoggerConfig struct {
 	state   protoimpl.MessageState `protogen:"open.v1"`
 	Options *LogOptionsGeneral     `protobuf:"bytes,1,opt,name=options" json:"options,omitempty"` // general logging options (format, level)
 	Fields  *LogOptionsHTTP        `protobuf:"bytes,2,opt,name=fields" json:"fields,omitempty"`   // HTTP-specific field selection and formatting
+	// Output destination (supports environment variable interpolation with ${VAR_NAME})
+	// Examples: "stdout", "stderr", "/var/log/app.log", "file:///var/log/app-${HOSTNAME}.log"
+	Output *string `protobuf:"bytes,3,opt,name=output,def=stdout" json:"output,omitempty"`
+	// Preset configuration (applied before custom field overrides)
+	Preset *LogPreset `protobuf:"varint,4,opt,name=preset,enum=settings.v1alpha1.middleware.v1.LogPreset,def=0" json:"preset,omitempty"`
 	// Path filtering - paths are matched as prefixes
-	IncludeOnlyPaths []string `protobuf:"bytes,3,rep,name=include_only_paths,json=includeOnlyPaths" json:"include_only_paths,omitempty"` // if set, only log requests matching these path prefixes
-	ExcludePaths     []string `protobuf:"bytes,4,rep,name=exclude_paths,json=excludePaths" json:"exclude_paths,omitempty"`               // exclude requests matching these path prefixes (e.g., "/health", "/metrics")
+	IncludeOnlyPaths []string `protobuf:"bytes,5,rep,name=include_only_paths,json=includeOnlyPaths" json:"include_only_paths,omitempty"` // if set, only log requests matching these path prefixes
+	ExcludePaths     []string `protobuf:"bytes,6,rep,name=exclude_paths,json=excludePaths" json:"exclude_paths,omitempty"`               // exclude requests matching these path prefixes (e.g., "/health", "/metrics")
 	// Method filtering
-	IncludeOnlyMethods []string `protobuf:"bytes,5,rep,name=include_only_methods,json=includeOnlyMethods" json:"include_only_methods,omitempty"` // if set, only log these HTTP methods (e.g., ["GET", "POST"])
-	ExcludeMethods     []string `protobuf:"bytes,6,rep,name=exclude_methods,json=excludeMethods" json:"exclude_methods,omitempty"`               // exclude these HTTP methods from logging (e.g., ["OPTIONS"])
+	IncludeOnlyMethods []string `protobuf:"bytes,7,rep,name=include_only_methods,json=includeOnlyMethods" json:"include_only_methods,omitempty"` // if set, only log these HTTP methods (e.g., ["GET", "POST"])
+	ExcludeMethods     []string `protobuf:"bytes,8,rep,name=exclude_methods,json=excludeMethods" json:"exclude_methods,omitempty"`               // exclude these HTTP methods from logging (e.g., ["OPTIONS"])
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
+
+// Default values for ConsoleLoggerConfig fields.
+const (
+	Default_ConsoleLoggerConfig_Output = string("stdout")
+	Default_ConsoleLoggerConfig_Preset = LogPreset_PRESET_UNSPECIFIED
+)
 
 func (x *ConsoleLoggerConfig) Reset() {
 	*x = ConsoleLoggerConfig{}
@@ -377,6 +444,20 @@ func (x *ConsoleLoggerConfig) GetFields() *LogOptionsHTTP {
 		return x.Fields
 	}
 	return nil
+}
+
+func (x *ConsoleLoggerConfig) GetOutput() string {
+	if x != nil && x.Output != nil {
+		return *x.Output
+	}
+	return Default_ConsoleLoggerConfig_Output
+}
+
+func (x *ConsoleLoggerConfig) GetPreset() LogPreset {
+	if x != nil && x.Preset != nil {
+		return *x.Preset
+	}
+	return Default_ConsoleLoggerConfig_Preset
 }
 
 func (x *ConsoleLoggerConfig) GetIncludeOnlyPaths() []string {
@@ -548,14 +629,22 @@ const file_settings_v1alpha1_middleware_v1_logger_proto_rawDesc = "" +
 	"\tbody_size\x18\x04 \x01(\bR\bbodySize\x12\x18\n" +
 	"\aheaders\x18\x05 \x01(\bR\aheaders\x12'\n" +
 	"\x0finclude_headers\x18\x06 \x03(\tR\x0eincludeHeaders\x12'\n" +
-	"\x0fexclude_headers\x18\a \x03(\tR\x0eexcludeHeaders\"\xda\x02\n" +
+	"\x0fexclude_headers\x18\a \x03(\tR\x0eexcludeHeaders\"\xd2\x03\n" +
 	"\x13ConsoleLoggerConfig\x12L\n" +
 	"\aoptions\x18\x01 \x01(\v22.settings.v1alpha1.middleware.v1.LogOptionsGeneralR\aoptions\x12G\n" +
-	"\x06fields\x18\x02 \x01(\v2/.settings.v1alpha1.middleware.v1.LogOptionsHTTPR\x06fields\x12,\n" +
-	"\x12include_only_paths\x18\x03 \x03(\tR\x10includeOnlyPaths\x12#\n" +
-	"\rexclude_paths\x18\x04 \x03(\tR\fexcludePaths\x120\n" +
-	"\x14include_only_methods\x18\x05 \x03(\tR\x12includeOnlyMethods\x12'\n" +
-	"\x0fexclude_methods\x18\x06 \x03(\tR\x0eexcludeMethodsBIZGgithub.com/atlanticdynamic/firelynx/gen/settings/v1alpha1/middleware/v1b\beditionsp\xe8\a"
+	"\x06fields\x18\x02 \x01(\v2/.settings.v1alpha1.middleware.v1.LogOptionsHTTPR\x06fields\x12\x1e\n" +
+	"\x06output\x18\x03 \x01(\t:\x06stdoutR\x06output\x12V\n" +
+	"\x06preset\x18\x04 \x01(\x0e2*.settings.v1alpha1.middleware.v1.LogPreset:\x12PRESET_UNSPECIFIEDR\x06preset\x12,\n" +
+	"\x12include_only_paths\x18\x05 \x03(\tR\x10includeOnlyPaths\x12#\n" +
+	"\rexclude_paths\x18\x06 \x03(\tR\fexcludePaths\x120\n" +
+	"\x14include_only_methods\x18\a \x03(\tR\x12includeOnlyMethods\x12'\n" +
+	"\x0fexclude_methods\x18\b \x03(\tR\x0eexcludeMethods*s\n" +
+	"\tLogPreset\x12\x16\n" +
+	"\x12PRESET_UNSPECIFIED\x10\x00\x12\x12\n" +
+	"\x0ePRESET_MINIMAL\x10\x01\x12\x13\n" +
+	"\x0fPRESET_STANDARD\x10\x02\x12\x13\n" +
+	"\x0fPRESET_DETAILED\x10\x03\x12\x10\n" +
+	"\fPRESET_DEBUG\x10\x04BIZGgithub.com/atlanticdynamic/firelynx/gen/settings/v1alpha1/middleware/v1b\beditionsp\xe8\a"
 
 var (
 	file_settings_v1alpha1_middleware_v1_logger_proto_rawDescOnce sync.Once
@@ -569,28 +658,30 @@ func file_settings_v1alpha1_middleware_v1_logger_proto_rawDescGZIP() []byte {
 	return file_settings_v1alpha1_middleware_v1_logger_proto_rawDescData
 }
 
-var file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
 var file_settings_v1alpha1_middleware_v1_logger_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_settings_v1alpha1_middleware_v1_logger_proto_goTypes = []any{
-	(LogOptionsGeneral_Format)(0),          // 0: settings.v1alpha1.middleware.v1.LogOptionsGeneral.Format
-	(LogOptionsGeneral_Level)(0),           // 1: settings.v1alpha1.middleware.v1.LogOptionsGeneral.Level
-	(*LogOptionsGeneral)(nil),              // 2: settings.v1alpha1.middleware.v1.LogOptionsGeneral
-	(*LogOptionsHTTP)(nil),                 // 3: settings.v1alpha1.middleware.v1.LogOptionsHTTP
-	(*ConsoleLoggerConfig)(nil),            // 4: settings.v1alpha1.middleware.v1.ConsoleLoggerConfig
-	(*LogOptionsHTTP_DirectionConfig)(nil), // 5: settings.v1alpha1.middleware.v1.LogOptionsHTTP.DirectionConfig
+	(LogPreset)(0),                         // 0: settings.v1alpha1.middleware.v1.LogPreset
+	(LogOptionsGeneral_Format)(0),          // 1: settings.v1alpha1.middleware.v1.LogOptionsGeneral.Format
+	(LogOptionsGeneral_Level)(0),           // 2: settings.v1alpha1.middleware.v1.LogOptionsGeneral.Level
+	(*LogOptionsGeneral)(nil),              // 3: settings.v1alpha1.middleware.v1.LogOptionsGeneral
+	(*LogOptionsHTTP)(nil),                 // 4: settings.v1alpha1.middleware.v1.LogOptionsHTTP
+	(*ConsoleLoggerConfig)(nil),            // 5: settings.v1alpha1.middleware.v1.ConsoleLoggerConfig
+	(*LogOptionsHTTP_DirectionConfig)(nil), // 6: settings.v1alpha1.middleware.v1.LogOptionsHTTP.DirectionConfig
 }
 var file_settings_v1alpha1_middleware_v1_logger_proto_depIdxs = []int32{
-	0, // 0: settings.v1alpha1.middleware.v1.LogOptionsGeneral.format:type_name -> settings.v1alpha1.middleware.v1.LogOptionsGeneral.Format
-	1, // 1: settings.v1alpha1.middleware.v1.LogOptionsGeneral.level:type_name -> settings.v1alpha1.middleware.v1.LogOptionsGeneral.Level
-	5, // 2: settings.v1alpha1.middleware.v1.LogOptionsHTTP.request:type_name -> settings.v1alpha1.middleware.v1.LogOptionsHTTP.DirectionConfig
-	5, // 3: settings.v1alpha1.middleware.v1.LogOptionsHTTP.response:type_name -> settings.v1alpha1.middleware.v1.LogOptionsHTTP.DirectionConfig
-	2, // 4: settings.v1alpha1.middleware.v1.ConsoleLoggerConfig.options:type_name -> settings.v1alpha1.middleware.v1.LogOptionsGeneral
-	3, // 5: settings.v1alpha1.middleware.v1.ConsoleLoggerConfig.fields:type_name -> settings.v1alpha1.middleware.v1.LogOptionsHTTP
-	6, // [6:6] is the sub-list for method output_type
-	6, // [6:6] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	1, // 0: settings.v1alpha1.middleware.v1.LogOptionsGeneral.format:type_name -> settings.v1alpha1.middleware.v1.LogOptionsGeneral.Format
+	2, // 1: settings.v1alpha1.middleware.v1.LogOptionsGeneral.level:type_name -> settings.v1alpha1.middleware.v1.LogOptionsGeneral.Level
+	6, // 2: settings.v1alpha1.middleware.v1.LogOptionsHTTP.request:type_name -> settings.v1alpha1.middleware.v1.LogOptionsHTTP.DirectionConfig
+	6, // 3: settings.v1alpha1.middleware.v1.LogOptionsHTTP.response:type_name -> settings.v1alpha1.middleware.v1.LogOptionsHTTP.DirectionConfig
+	3, // 4: settings.v1alpha1.middleware.v1.ConsoleLoggerConfig.options:type_name -> settings.v1alpha1.middleware.v1.LogOptionsGeneral
+	4, // 5: settings.v1alpha1.middleware.v1.ConsoleLoggerConfig.fields:type_name -> settings.v1alpha1.middleware.v1.LogOptionsHTTP
+	0, // 6: settings.v1alpha1.middleware.v1.ConsoleLoggerConfig.preset:type_name -> settings.v1alpha1.middleware.v1.LogPreset
+	7, // [7:7] is the sub-list for method output_type
+	7, // [7:7] is the sub-list for method input_type
+	7, // [7:7] is the sub-list for extension type_name
+	7, // [7:7] is the sub-list for extension extendee
+	0, // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_settings_v1alpha1_middleware_v1_logger_proto_init() }
@@ -603,7 +694,7 @@ func file_settings_v1alpha1_middleware_v1_logger_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_settings_v1alpha1_middleware_v1_logger_proto_rawDesc), len(file_settings_v1alpha1_middleware_v1_logger_proto_rawDesc)),
-			NumEnums:      2,
+			NumEnums:      3,
 			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/gen/settings/v1alpha1/middleware/v1/logger.pb.go
+++ b/gen/settings/v1alpha1/middleware/v1/logger.pb.go
@@ -21,62 +21,6 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// Preset configurations for common logging scenarios
-type LogPreset int32
-
-const (
-	LogPreset_PRESET_UNSPECIFIED LogPreset = 0
-	LogPreset_PRESET_MINIMAL     LogPreset = 1 // Only method, path, status code
-	LogPreset_PRESET_STANDARD    LogPreset = 2 // Minimal + client IP, duration
-	LogPreset_PRESET_DETAILED    LogPreset = 3 // Standard + headers, query params
-	LogPreset_PRESET_DEBUG       LogPreset = 4 // Everything including request/response bodies
-)
-
-// Enum value maps for LogPreset.
-var (
-	LogPreset_name = map[int32]string{
-		0: "PRESET_UNSPECIFIED",
-		1: "PRESET_MINIMAL",
-		2: "PRESET_STANDARD",
-		3: "PRESET_DETAILED",
-		4: "PRESET_DEBUG",
-	}
-	LogPreset_value = map[string]int32{
-		"PRESET_UNSPECIFIED": 0,
-		"PRESET_MINIMAL":     1,
-		"PRESET_STANDARD":    2,
-		"PRESET_DETAILED":    3,
-		"PRESET_DEBUG":       4,
-	}
-)
-
-func (x LogPreset) Enum() *LogPreset {
-	p := new(LogPreset)
-	*p = x
-	return p
-}
-
-func (x LogPreset) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (LogPreset) Descriptor() protoreflect.EnumDescriptor {
-	return file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[0].Descriptor()
-}
-
-func (LogPreset) Type() protoreflect.EnumType {
-	return &file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[0]
-}
-
-func (x LogPreset) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use LogPreset.Descriptor instead.
-func (LogPreset) EnumDescriptor() ([]byte, []int) {
-	return file_settings_v1alpha1_middleware_v1_logger_proto_rawDescGZIP(), []int{0}
-}
-
 type LogOptionsGeneral_Format int32
 
 const (
@@ -110,11 +54,11 @@ func (x LogOptionsGeneral_Format) String() string {
 }
 
 func (LogOptionsGeneral_Format) Descriptor() protoreflect.EnumDescriptor {
-	return file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[1].Descriptor()
+	return file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[0].Descriptor()
 }
 
 func (LogOptionsGeneral_Format) Type() protoreflect.EnumType {
-	return &file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[1]
+	return &file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[0]
 }
 
 func (x LogOptionsGeneral_Format) Number() protoreflect.EnumNumber {
@@ -168,11 +112,11 @@ func (x LogOptionsGeneral_Level) String() string {
 }
 
 func (LogOptionsGeneral_Level) Descriptor() protoreflect.EnumDescriptor {
-	return file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[2].Descriptor()
+	return file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[1].Descriptor()
 }
 
 func (LogOptionsGeneral_Level) Type() protoreflect.EnumType {
-	return &file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[2]
+	return &file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[1]
 }
 
 func (x LogOptionsGeneral_Level) Number() protoreflect.EnumNumber {
@@ -182,6 +126,62 @@ func (x LogOptionsGeneral_Level) Number() protoreflect.EnumNumber {
 // Deprecated: Use LogOptionsGeneral_Level.Descriptor instead.
 func (LogOptionsGeneral_Level) EnumDescriptor() ([]byte, []int) {
 	return file_settings_v1alpha1_middleware_v1_logger_proto_rawDescGZIP(), []int{0, 1}
+}
+
+// Preset configuration bundles for common logging scenarios
+type ConsoleLoggerConfig_LogPreset int32
+
+const (
+	ConsoleLoggerConfig_PRESET_UNSPECIFIED ConsoleLoggerConfig_LogPreset = 0
+	ConsoleLoggerConfig_PRESET_MINIMAL     ConsoleLoggerConfig_LogPreset = 1 // Only method, path, status code
+	ConsoleLoggerConfig_PRESET_STANDARD    ConsoleLoggerConfig_LogPreset = 2 // Minimal + client IP, duration
+	ConsoleLoggerConfig_PRESET_DETAILED    ConsoleLoggerConfig_LogPreset = 3 // Standard + headers, query params
+	ConsoleLoggerConfig_PRESET_DEBUG       ConsoleLoggerConfig_LogPreset = 4 // Everything including request/response bodies
+)
+
+// Enum value maps for ConsoleLoggerConfig_LogPreset.
+var (
+	ConsoleLoggerConfig_LogPreset_name = map[int32]string{
+		0: "PRESET_UNSPECIFIED",
+		1: "PRESET_MINIMAL",
+		2: "PRESET_STANDARD",
+		3: "PRESET_DETAILED",
+		4: "PRESET_DEBUG",
+	}
+	ConsoleLoggerConfig_LogPreset_value = map[string]int32{
+		"PRESET_UNSPECIFIED": 0,
+		"PRESET_MINIMAL":     1,
+		"PRESET_STANDARD":    2,
+		"PRESET_DETAILED":    3,
+		"PRESET_DEBUG":       4,
+	}
+)
+
+func (x ConsoleLoggerConfig_LogPreset) Enum() *ConsoleLoggerConfig_LogPreset {
+	p := new(ConsoleLoggerConfig_LogPreset)
+	*p = x
+	return p
+}
+
+func (x ConsoleLoggerConfig_LogPreset) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ConsoleLoggerConfig_LogPreset) Descriptor() protoreflect.EnumDescriptor {
+	return file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[2].Descriptor()
+}
+
+func (ConsoleLoggerConfig_LogPreset) Type() protoreflect.EnumType {
+	return &file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes[2]
+}
+
+func (x ConsoleLoggerConfig_LogPreset) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ConsoleLoggerConfig_LogPreset.Descriptor instead.
+func (ConsoleLoggerConfig_LogPreset) EnumDescriptor() ([]byte, []int) {
+	return file_settings_v1alpha1_middleware_v1_logger_proto_rawDescGZIP(), []int{2, 0}
 }
 
 type LogOptionsGeneral struct {
@@ -385,7 +385,7 @@ type ConsoleLoggerConfig struct {
 	// Examples: "stdout", "stderr", "/var/log/app.log", "file:///var/log/app-${HOSTNAME}.log"
 	Output *string `protobuf:"bytes,3,opt,name=output,def=stdout" json:"output,omitempty"`
 	// Preset configuration (applied before custom field overrides)
-	Preset *LogPreset `protobuf:"varint,4,opt,name=preset,enum=settings.v1alpha1.middleware.v1.LogPreset,def=0" json:"preset,omitempty"`
+	Preset *ConsoleLoggerConfig_LogPreset `protobuf:"varint,4,opt,name=preset,enum=settings.v1alpha1.middleware.v1.ConsoleLoggerConfig_LogPreset,def=0" json:"preset,omitempty"`
 	// Path filtering - paths are matched as prefixes
 	IncludeOnlyPaths []string `protobuf:"bytes,5,rep,name=include_only_paths,json=includeOnlyPaths" json:"include_only_paths,omitempty"` // if set, only log requests matching these path prefixes
 	ExcludePaths     []string `protobuf:"bytes,6,rep,name=exclude_paths,json=excludePaths" json:"exclude_paths,omitempty"`               // exclude requests matching these path prefixes (e.g., "/health", "/metrics")
@@ -399,7 +399,7 @@ type ConsoleLoggerConfig struct {
 // Default values for ConsoleLoggerConfig fields.
 const (
 	Default_ConsoleLoggerConfig_Output = string("stdout")
-	Default_ConsoleLoggerConfig_Preset = LogPreset_PRESET_UNSPECIFIED
+	Default_ConsoleLoggerConfig_Preset = ConsoleLoggerConfig_PRESET_UNSPECIFIED
 )
 
 func (x *ConsoleLoggerConfig) Reset() {
@@ -453,7 +453,7 @@ func (x *ConsoleLoggerConfig) GetOutput() string {
 	return Default_ConsoleLoggerConfig_Output
 }
 
-func (x *ConsoleLoggerConfig) GetPreset() LogPreset {
+func (x *ConsoleLoggerConfig) GetPreset() ConsoleLoggerConfig_LogPreset {
 	if x != nil && x.Preset != nil {
 		return *x.Preset
 	}
@@ -629,16 +629,16 @@ const file_settings_v1alpha1_middleware_v1_logger_proto_rawDesc = "" +
 	"\tbody_size\x18\x04 \x01(\bR\bbodySize\x12\x18\n" +
 	"\aheaders\x18\x05 \x01(\bR\aheaders\x12'\n" +
 	"\x0finclude_headers\x18\x06 \x03(\tR\x0eincludeHeaders\x12'\n" +
-	"\x0fexclude_headers\x18\a \x03(\tR\x0eexcludeHeaders\"\xd2\x03\n" +
+	"\x0fexclude_headers\x18\a \x03(\tR\x0eexcludeHeaders\"\xdb\x04\n" +
 	"\x13ConsoleLoggerConfig\x12L\n" +
 	"\aoptions\x18\x01 \x01(\v22.settings.v1alpha1.middleware.v1.LogOptionsGeneralR\aoptions\x12G\n" +
 	"\x06fields\x18\x02 \x01(\v2/.settings.v1alpha1.middleware.v1.LogOptionsHTTPR\x06fields\x12\x1e\n" +
-	"\x06output\x18\x03 \x01(\t:\x06stdoutR\x06output\x12V\n" +
-	"\x06preset\x18\x04 \x01(\x0e2*.settings.v1alpha1.middleware.v1.LogPreset:\x12PRESET_UNSPECIFIEDR\x06preset\x12,\n" +
+	"\x06output\x18\x03 \x01(\t:\x06stdoutR\x06output\x12j\n" +
+	"\x06preset\x18\x04 \x01(\x0e2>.settings.v1alpha1.middleware.v1.ConsoleLoggerConfig.LogPreset:\x12PRESET_UNSPECIFIEDR\x06preset\x12,\n" +
 	"\x12include_only_paths\x18\x05 \x03(\tR\x10includeOnlyPaths\x12#\n" +
 	"\rexclude_paths\x18\x06 \x03(\tR\fexcludePaths\x120\n" +
 	"\x14include_only_methods\x18\a \x03(\tR\x12includeOnlyMethods\x12'\n" +
-	"\x0fexclude_methods\x18\b \x03(\tR\x0eexcludeMethods*s\n" +
+	"\x0fexclude_methods\x18\b \x03(\tR\x0eexcludeMethods\"s\n" +
 	"\tLogPreset\x12\x16\n" +
 	"\x12PRESET_UNSPECIFIED\x10\x00\x12\x12\n" +
 	"\x0ePRESET_MINIMAL\x10\x01\x12\x13\n" +
@@ -661,22 +661,22 @@ func file_settings_v1alpha1_middleware_v1_logger_proto_rawDescGZIP() []byte {
 var file_settings_v1alpha1_middleware_v1_logger_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
 var file_settings_v1alpha1_middleware_v1_logger_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_settings_v1alpha1_middleware_v1_logger_proto_goTypes = []any{
-	(LogPreset)(0),                         // 0: settings.v1alpha1.middleware.v1.LogPreset
-	(LogOptionsGeneral_Format)(0),          // 1: settings.v1alpha1.middleware.v1.LogOptionsGeneral.Format
-	(LogOptionsGeneral_Level)(0),           // 2: settings.v1alpha1.middleware.v1.LogOptionsGeneral.Level
+	(LogOptionsGeneral_Format)(0),          // 0: settings.v1alpha1.middleware.v1.LogOptionsGeneral.Format
+	(LogOptionsGeneral_Level)(0),           // 1: settings.v1alpha1.middleware.v1.LogOptionsGeneral.Level
+	(ConsoleLoggerConfig_LogPreset)(0),     // 2: settings.v1alpha1.middleware.v1.ConsoleLoggerConfig.LogPreset
 	(*LogOptionsGeneral)(nil),              // 3: settings.v1alpha1.middleware.v1.LogOptionsGeneral
 	(*LogOptionsHTTP)(nil),                 // 4: settings.v1alpha1.middleware.v1.LogOptionsHTTP
 	(*ConsoleLoggerConfig)(nil),            // 5: settings.v1alpha1.middleware.v1.ConsoleLoggerConfig
 	(*LogOptionsHTTP_DirectionConfig)(nil), // 6: settings.v1alpha1.middleware.v1.LogOptionsHTTP.DirectionConfig
 }
 var file_settings_v1alpha1_middleware_v1_logger_proto_depIdxs = []int32{
-	1, // 0: settings.v1alpha1.middleware.v1.LogOptionsGeneral.format:type_name -> settings.v1alpha1.middleware.v1.LogOptionsGeneral.Format
-	2, // 1: settings.v1alpha1.middleware.v1.LogOptionsGeneral.level:type_name -> settings.v1alpha1.middleware.v1.LogOptionsGeneral.Level
+	0, // 0: settings.v1alpha1.middleware.v1.LogOptionsGeneral.format:type_name -> settings.v1alpha1.middleware.v1.LogOptionsGeneral.Format
+	1, // 1: settings.v1alpha1.middleware.v1.LogOptionsGeneral.level:type_name -> settings.v1alpha1.middleware.v1.LogOptionsGeneral.Level
 	6, // 2: settings.v1alpha1.middleware.v1.LogOptionsHTTP.request:type_name -> settings.v1alpha1.middleware.v1.LogOptionsHTTP.DirectionConfig
 	6, // 3: settings.v1alpha1.middleware.v1.LogOptionsHTTP.response:type_name -> settings.v1alpha1.middleware.v1.LogOptionsHTTP.DirectionConfig
 	3, // 4: settings.v1alpha1.middleware.v1.ConsoleLoggerConfig.options:type_name -> settings.v1alpha1.middleware.v1.LogOptionsGeneral
 	4, // 5: settings.v1alpha1.middleware.v1.ConsoleLoggerConfig.fields:type_name -> settings.v1alpha1.middleware.v1.LogOptionsHTTP
-	0, // 6: settings.v1alpha1.middleware.v1.ConsoleLoggerConfig.preset:type_name -> settings.v1alpha1.middleware.v1.LogPreset
+	2, // 6: settings.v1alpha1.middleware.v1.ConsoleLoggerConfig.preset:type_name -> settings.v1alpha1.middleware.v1.ConsoleLoggerConfig.LogPreset
 	7, // [7:7] is the sub-list for method output_type
 	7, // [7:7] is the sub-list for method input_type
 	7, // [7:7] is the sub-list for extension type_name

--- a/internal/config/README.md
+++ b/internal/config/README.md
@@ -50,3 +50,17 @@ listener := cfg.Listeners.FindByID("public-http")
 ```
 
 The rest of the server interacts with configuration exclusively through this API, allowing the TOML and protobuf schemas to evolve without touching runtime code.
+
+## Environment Variable Interpolation
+
+Config fields can support environment variable interpolation using `${VAR_NAME}` syntax. To add this to new fields:
+
+1. **Protobuf**: Add field comment documenting interpolation support
+2. **Domain conversion**: Use `interpolation.ExpandEnvVars()` when converting from protobuf
+3. **Validation**: Validate the expanded value, not the raw template
+
+Example protobuf field:
+```protobuf
+// Output destination (supports environment variable interpolation with ${VAR_NAME})
+string output = 3 [default = "stdout"];
+```

--- a/internal/config/endpoints/middleware/logger/config_integration_test.go
+++ b/internal/config/endpoints/middleware/logger/config_integration_test.go
@@ -1,0 +1,65 @@
+package logger_test
+
+import (
+	_ "embed"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/atlanticdynamic/firelynx/internal/config"
+	"github.com/atlanticdynamic/firelynx/internal/config/endpoints/middleware/logger"
+	"github.com/atlanticdynamic/firelynx/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed testdata/standard_preset_config.toml
+var standardPresetConfigTOML string
+
+func TestFullConfigParsingWithPreset(t *testing.T) {
+	t.Parallel()
+
+	port := testutil.GetRandomPort(t)
+
+	// Update the embedded TOML with dynamic values
+	tomlData := strings.ReplaceAll(
+		standardPresetConfigTOML,
+		"127.0.0.1:8080",
+		fmt.Sprintf("127.0.0.1:%d", port),
+	)
+	tomlData = strings.ReplaceAll(tomlData, "/tmp/test.log", fmt.Sprintf("/tmp/test-%d.log", port))
+
+	cfg, err := config.NewConfigFromBytes([]byte(tomlData))
+	require.NoError(t, err, "Config should load successfully")
+
+	err = cfg.Validate()
+	require.NoError(t, err, "Config should validate successfully")
+
+	endpoints := cfg.Endpoints
+	require.Len(t, endpoints, 1, "Should have one endpoint")
+
+	endpoint := endpoints[0]
+	middlewares := endpoint.Middlewares
+	require.Len(t, middlewares, 1, "Should have one middleware")
+
+	middleware := middlewares[0]
+	require.Equal(t, "test-logger", middleware.ID, "Middleware ID should match")
+
+	loggerConfig, ok := middleware.Config.(*logger.ConsoleLogger)
+	require.True(t, ok, "Middleware config should be console logger type")
+	require.NotNil(t, loggerConfig, "Should have console logger config")
+
+	assert.Equal(
+		t,
+		logger.PresetStandard,
+		loggerConfig.Preset,
+		"Preset should be parsed correctly from TOML",
+	)
+
+	loggerConfig.ApplyPreset()
+	assert.True(t, loggerConfig.Fields.Method, "Standard preset should enable method")
+	assert.True(t, loggerConfig.Fields.Path, "Standard preset should enable path")
+	assert.True(t, loggerConfig.Fields.StatusCode, "Standard preset should enable status_code")
+	assert.True(t, loggerConfig.Fields.ClientIP, "Standard preset should enable client_ip")
+	assert.True(t, loggerConfig.Fields.Duration, "Standard preset should enable duration")
+}

--- a/internal/config/endpoints/middleware/logger/console.go
+++ b/internal/config/endpoints/middleware/logger/console.go
@@ -304,7 +304,10 @@ func (c *ConsoleLogger) ToTree() *fancy.ComponentTree {
 // validateOutputWritability checks if the output destination is writable
 func (c *ConsoleLogger) validateOutputWritability() error {
 	// Expand environment variables in the output path
-	expandedOutput := interpolation.ExpandEnvVars(c.Output)
+	expandedOutput, err := interpolation.ExpandEnvVars(c.Output)
+	if err != nil {
+		return fmt.Errorf("environment variable expansion failed: %w", err)
+	}
 
 	// Check if it's a file path that needs validation
 	writerType := writers.ParseWriterType(expandedOutput)

--- a/internal/config/endpoints/middleware/logger/console_test.go
+++ b/internal/config/endpoints/middleware/logger/console_test.go
@@ -315,9 +315,9 @@ func TestConsoleLogger_validateOutputWritability(t *testing.T) {
 	// Set up temp directory structure for relative path testing
 	tempDir := t.TempDir()
 	subDir := filepath.Join(tempDir, "subdir")
-	err := os.MkdirAll(subDir, 0755)
+	err := os.MkdirAll(subDir, 0o755)
 	require.NoError(t, err)
-	
+
 	// Change to subdirectory so relative paths work predictably
 	originalWd, err := os.Getwd()
 	require.NoError(t, err)

--- a/internal/config/endpoints/middleware/logger/console_test.go
+++ b/internal/config/endpoints/middleware/logger/console_test.go
@@ -58,7 +58,7 @@ func TestConsoleLogger_Validate(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name: "Negative max body size",
+			name: "Negative request max body size",
 			logger: &ConsoleLogger{
 				Fields: LogOptionsHTTP{
 					Request: DirectionConfig{
@@ -68,13 +68,35 @@ func TestConsoleLogger_Validate(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			name: "Negative response max body size",
+			logger: &ConsoleLogger{
+				Fields: LogOptionsHTTP{
+					Response: DirectionConfig{
+						MaxBodySize: -1,
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "Invalid preset",
+			logger: &ConsoleLogger{
+				Preset: "invalid",
+			},
+			expectError: true,
+		},
+		{
+			name: "Empty output gets default",
+			logger: &ConsoleLogger{
+				Output: "",
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			err := tt.logger.Validate()
 			if tt.expectError {
 				assert.Error(t, err)
@@ -88,17 +110,198 @@ func TestConsoleLogger_Validate(t *testing.T) {
 func TestConsoleLogger_String(t *testing.T) {
 	t.Parallel()
 
-	logger := NewConsoleLogger()
-	str := logger.String()
-	assert.Contains(t, str, "Format: json")
-	assert.Contains(t, str, "Level: info")
+	tests := []struct {
+		name     string
+		logger   *ConsoleLogger
+		contains []string
+	}{
+		{
+			name:   "Default logger",
+			logger: NewConsoleLogger(),
+			contains: []string{
+				"Format: json",
+				"Level: info",
+				"Output: stdout",
+			},
+		},
+		{
+			name: "Logger with preset",
+			logger: &ConsoleLogger{
+				Options: LogOptionsGeneral{
+					Format: FormatTxt,
+					Level:  LevelDebug,
+				},
+				Output: "stderr",
+				Preset: PresetMinimal,
+			},
+			contains: []string{
+				"Format: txt",
+				"Level: debug",
+				"Output: stderr",
+				"Preset: minimal",
+			},
+		},
+		{
+			name: "Logger with path filtering",
+			logger: &ConsoleLogger{
+				Options: LogOptionsGeneral{
+					Format: FormatJSON,
+					Level:  LevelWarn,
+				},
+				Output:           "file.log",
+				IncludeOnlyPaths: []string{"/api", "/health"},
+				ExcludePaths:     []string{"/debug", "/test"},
+			},
+			contains: []string{
+				"Format: json",
+				"Level: warn",
+				"Output: file.log",
+				"Include paths: [/api /health]",
+				"Exclude paths: [/debug /test]",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			str := tt.logger.String()
+			for _, expected := range tt.contains {
+				assert.Contains(t, str, expected)
+			}
+		})
+	}
 }
 
 func TestConsoleLogger_ToTree(t *testing.T) {
 	t.Parallel()
 
-	logger := NewConsoleLogger()
-	tree := logger.ToTree()
-	assert.NotNil(t, tree)
-	assert.NotNil(t, tree.Tree())
+	tests := []struct {
+		name   string
+		logger *ConsoleLogger
+	}{
+		{
+			name:   "Default logger",
+			logger: NewConsoleLogger(),
+		},
+		{
+			name: "Logger with preset",
+			logger: &ConsoleLogger{
+				Options: LogOptionsGeneral{
+					Format: FormatTxt,
+					Level:  LevelDebug,
+				},
+				Output: "stderr",
+				Preset: PresetDetailed,
+			},
+		},
+		{
+			name: "Logger with path filtering",
+			logger: &ConsoleLogger{
+				Options: LogOptionsGeneral{
+					Format: FormatJSON,
+					Level:  LevelWarn,
+				},
+				Output:           "file.log",
+				IncludeOnlyPaths: []string{"/api", "/health"},
+				ExcludePaths:     []string{"/debug", "/test"},
+				Fields: LogOptionsHTTP{
+					Method:     true,
+					Path:       true,
+					StatusCode: true,
+				},
+			},
+		},
+		{
+			name: "Logger with no HTTP fields",
+			logger: &ConsoleLogger{
+				Options: LogOptionsGeneral{
+					Format: FormatJSON,
+					Level:  LevelInfo,
+				},
+				Output: "stdout",
+				Fields: LogOptionsHTTP{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tree := tt.logger.ToTree()
+			assert.NotNil(t, tree)
+			assert.NotNil(t, tree.Tree())
+		})
+	}
+}
+
+func TestConsoleLogger_ApplyPreset(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		preset         Preset
+		expectedFields func(fields LogOptionsHTTP) bool
+	}{
+		{
+			name:   "Minimal preset",
+			preset: PresetMinimal,
+			expectedFields: func(fields LogOptionsHTTP) bool {
+				return fields.Method && fields.Path && fields.StatusCode &&
+					!fields.ClientIP && !fields.Duration && !fields.QueryParams
+			},
+		},
+		{
+			name:   "Standard preset",
+			preset: PresetStandard,
+			expectedFields: func(fields LogOptionsHTTP) bool {
+				return fields.Method && fields.Path && fields.StatusCode &&
+					fields.ClientIP && fields.Duration && !fields.QueryParams
+			},
+		},
+		{
+			name:   "Detailed preset",
+			preset: PresetDetailed,
+			expectedFields: func(fields LogOptionsHTTP) bool {
+				return fields.Method && fields.Path && fields.StatusCode &&
+					fields.ClientIP && fields.Duration && fields.QueryParams &&
+					fields.Protocol && fields.Host && fields.Scheme &&
+					fields.Request.Headers && fields.Response.Headers
+			},
+		},
+		{
+			name:   "Debug preset",
+			preset: PresetDebug,
+			expectedFields: func(fields LogOptionsHTTP) bool {
+				return fields.Method && fields.Path && fields.StatusCode &&
+					fields.ClientIP && fields.Duration && fields.QueryParams &&
+					fields.Protocol && fields.Host && fields.Scheme &&
+					fields.Request.Headers && fields.Response.Headers &&
+					fields.Request.Body && fields.Request.BodySize &&
+					fields.Response.Body && fields.Response.BodySize &&
+					fields.Request.MaxBodySize == 1024 && fields.Response.MaxBodySize == 1024
+			},
+		},
+		{
+			name:   "Unspecified preset (no change)",
+			preset: PresetUnspecified,
+			expectedFields: func(fields LogOptionsHTTP) bool {
+				return fields.Method && fields.Path && fields.StatusCode &&
+					!fields.ClientIP && !fields.Duration && !fields.QueryParams
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := NewConsoleLogger()
+			logger.Preset = tt.preset
+			logger.ApplyPreset()
+
+			assert.True(
+				t,
+				tt.expectedFields(logger.Fields),
+				"Expected fields configuration not met for preset %s",
+				tt.preset,
+			)
+		})
+	}
 }

--- a/internal/config/endpoints/middleware/logger/proto.go
+++ b/internal/config/endpoints/middleware/logger/proto.go
@@ -72,7 +72,11 @@ func FromProto(pbConfig *pb.ConsoleLoggerConfig) (*ConsoleLogger, error) {
 
 	// Convert output with environment variable interpolation
 	// Empty string defaults to stdout in CreateWriter
-	config.Output = interpolation.ExpandEnvVars(pbConfig.GetOutput())
+	expandedOutput, err := interpolation.ExpandEnvVars(pbConfig.GetOutput())
+	if err != nil {
+		return nil, fmt.Errorf("environment variable expansion failed: %w", err)
+	}
+	config.Output = expandedOutput
 
 	// Convert preset
 	config.Preset = presetFromProto(pbConfig.GetPreset())

--- a/internal/config/endpoints/middleware/logger/proto.go
+++ b/internal/config/endpoints/middleware/logger/proto.go
@@ -211,30 +211,30 @@ func directionConfigFromProto(pbConfig *pb.LogOptionsHTTP_DirectionConfig) Direc
 }
 
 // Helper functions for preset conversion
-func presetToProto(preset Preset) pb.LogPreset {
+func presetToProto(preset Preset) pb.ConsoleLoggerConfig_LogPreset {
 	switch preset {
 	case PresetMinimal:
-		return pb.LogPreset_PRESET_MINIMAL
+		return pb.ConsoleLoggerConfig_PRESET_MINIMAL
 	case PresetStandard:
-		return pb.LogPreset_PRESET_STANDARD
+		return pb.ConsoleLoggerConfig_PRESET_STANDARD
 	case PresetDetailed:
-		return pb.LogPreset_PRESET_DETAILED
+		return pb.ConsoleLoggerConfig_PRESET_DETAILED
 	case PresetDebug:
-		return pb.LogPreset_PRESET_DEBUG
+		return pb.ConsoleLoggerConfig_PRESET_DEBUG
 	default:
-		return pb.LogPreset_PRESET_UNSPECIFIED
+		return pb.ConsoleLoggerConfig_PRESET_UNSPECIFIED
 	}
 }
 
-func presetFromProto(pbPreset pb.LogPreset) Preset {
+func presetFromProto(pbPreset pb.ConsoleLoggerConfig_LogPreset) Preset {
 	switch pbPreset {
-	case pb.LogPreset_PRESET_MINIMAL:
+	case pb.ConsoleLoggerConfig_PRESET_MINIMAL:
 		return PresetMinimal
-	case pb.LogPreset_PRESET_STANDARD:
+	case pb.ConsoleLoggerConfig_PRESET_STANDARD:
 		return PresetStandard
-	case pb.LogPreset_PRESET_DETAILED:
+	case pb.ConsoleLoggerConfig_PRESET_DETAILED:
 		return PresetDetailed
-	case pb.LogPreset_PRESET_DEBUG:
+	case pb.ConsoleLoggerConfig_PRESET_DEBUG:
 		return PresetDebug
 	default:
 		return PresetUnspecified

--- a/internal/config/endpoints/middleware/logger/proto_test.go
+++ b/internal/config/endpoints/middleware/logger/proto_test.go
@@ -446,8 +446,6 @@ func TestDirectionConfigConversion(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Complete direction config", func(t *testing.T) {
-		t.Parallel()
-
 		domain := DirectionConfig{
 			Enabled:        true,
 			Body:           false,
@@ -474,8 +472,6 @@ func TestDirectionConfigConversion(t *testing.T) {
 	})
 
 	t.Run("Empty direction config", func(t *testing.T) {
-		t.Parallel()
-
 		domain := DirectionConfig{}
 
 		// Convert to proto
@@ -491,5 +487,41 @@ func TestDirectionConfigConversion(t *testing.T) {
 		// Convert back to domain
 		restored := directionConfigFromProto(proto)
 		assert.Equal(t, domain, restored)
+	})
+}
+
+func TestPresetConversion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		domain Preset
+		proto  pb.LogPreset
+	}{
+		{PresetMinimal, pb.LogPreset_PRESET_MINIMAL},
+		{PresetStandard, pb.LogPreset_PRESET_STANDARD},
+		{PresetDetailed, pb.LogPreset_PRESET_DETAILED},
+		{PresetDebug, pb.LogPreset_PRESET_DEBUG},
+		{PresetUnspecified, pb.LogPreset_PRESET_UNSPECIFIED},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.domain), func(t *testing.T) {
+			// Test domain to proto
+			protoPreset := presetToProto(tt.domain)
+			assert.Equal(t, tt.proto, protoPreset)
+
+			// Test proto to domain
+			domainPreset := presetFromProto(tt.proto)
+			assert.Equal(t, tt.domain, domainPreset)
+		})
+	}
+
+	t.Run("Invalid preset defaults to unspecified", func(t *testing.T) {
+		invalidPreset := Preset("invalid")
+		protoPreset := presetToProto(invalidPreset)
+		assert.Equal(t, pb.LogPreset_PRESET_UNSPECIFIED, protoPreset)
+
+		domainPreset := presetFromProto(pb.LogPreset(999))
+		assert.Equal(t, PresetUnspecified, domainPreset)
 	})
 }

--- a/internal/config/endpoints/middleware/logger/proto_test.go
+++ b/internal/config/endpoints/middleware/logger/proto_test.go
@@ -495,13 +495,13 @@ func TestPresetConversion(t *testing.T) {
 
 	tests := []struct {
 		domain Preset
-		proto  pb.LogPreset
+		proto  pb.ConsoleLoggerConfig_LogPreset
 	}{
-		{PresetMinimal, pb.LogPreset_PRESET_MINIMAL},
-		{PresetStandard, pb.LogPreset_PRESET_STANDARD},
-		{PresetDetailed, pb.LogPreset_PRESET_DETAILED},
-		{PresetDebug, pb.LogPreset_PRESET_DEBUG},
-		{PresetUnspecified, pb.LogPreset_PRESET_UNSPECIFIED},
+		{PresetMinimal, pb.ConsoleLoggerConfig_PRESET_MINIMAL},
+		{PresetStandard, pb.ConsoleLoggerConfig_PRESET_STANDARD},
+		{PresetDetailed, pb.ConsoleLoggerConfig_PRESET_DETAILED},
+		{PresetDebug, pb.ConsoleLoggerConfig_PRESET_DEBUG},
+		{PresetUnspecified, pb.ConsoleLoggerConfig_PRESET_UNSPECIFIED},
 	}
 
 	for _, tt := range tests {
@@ -519,9 +519,9 @@ func TestPresetConversion(t *testing.T) {
 	t.Run("Invalid preset defaults to unspecified", func(t *testing.T) {
 		invalidPreset := Preset("invalid")
 		protoPreset := presetToProto(invalidPreset)
-		assert.Equal(t, pb.LogPreset_PRESET_UNSPECIFIED, protoPreset)
+		assert.Equal(t, pb.ConsoleLoggerConfig_PRESET_UNSPECIFIED, protoPreset)
 
-		domainPreset := presetFromProto(pb.LogPreset(999))
+		domainPreset := presetFromProto(pb.ConsoleLoggerConfig_LogPreset(999))
 		assert.Equal(t, PresetUnspecified, domainPreset)
 	})
 }

--- a/internal/config/endpoints/middleware/logger/testdata/console_logger_config.toml.tmpl
+++ b/internal/config/endpoints/middleware/logger/testdata/console_logger_config.toml.tmpl
@@ -1,0 +1,30 @@
+[console_logger]
+output = "{{.Output}}"
+{{- if .Preset}}
+preset = "{{.Preset}}"
+{{- end}}
+
+[console_logger.options]
+format = "{{.Format}}"
+level = "{{.Level}}"
+
+{{- if .Fields}}
+[console_logger.fields]
+{{- range $key, $value := .Fields}}
+{{$key}} = {{$value}}
+{{- end}}
+
+{{- if .RequestConfig}}
+[console_logger.fields.request]
+{{- range $key, $value := .RequestConfig}}
+{{$key}} = {{if eq (printf "%T" $value) "[]string"}}{{printf "%#v" $value}}{{else}}{{$value}}{{end}}
+{{- end}}
+{{- end}}
+
+{{- if .ResponseConfig}}
+[console_logger.fields.response]
+{{- range $key, $value := .ResponseConfig}}
+{{$key}} = {{if eq (printf "%T" $value) "[]string"}}{{printf "%#v" $value}}{{else}}{{$value}}{{end}}
+{{- end}}
+{{- end}}
+{{- end}}

--- a/internal/config/endpoints/middleware/logger/testdata/standard_preset_config.toml
+++ b/internal/config/endpoints/middleware/logger/testdata/standard_preset_config.toml
@@ -1,0 +1,36 @@
+version = "v1"
+
+[[listeners]]
+id = "http"
+address = "127.0.0.1:8080"
+type = "http"
+
+[listeners.http]
+read_timeout = "30s"
+write_timeout = "30s"
+
+[[endpoints]]
+id = "main"
+listener_id = "http"
+
+[[endpoints.middlewares]]
+id = "test-logger"
+type = "console_logger"
+
+[endpoints.middlewares.console_logger]
+preset = "standard"
+output = "/tmp/test.log"
+
+[endpoints.middlewares.console_logger.options]
+format = "json"
+level = "info"
+
+[[endpoints.routes]]
+app_id = "test-echo"
+[endpoints.routes.http]
+path_prefix = "/"
+
+[[apps]]
+id = "test-echo"
+[apps.echo]
+response = "Test Response"

--- a/internal/config/endpoints/middleware/logger/testdata/standard_preset_config.toml.tmpl
+++ b/internal/config/endpoints/middleware/logger/testdata/standard_preset_config.toml.tmpl
@@ -2,7 +2,7 @@ version = "v1"
 
 [[listeners]]
 id = "http"
-address = "127.0.0.1:8080"
+address = "127.0.0.1:{{.Port}}"
 type = "http"
 
 [listeners.http]
@@ -19,7 +19,7 @@ type = "console_logger"
 
 [endpoints.middlewares.console_logger]
 preset = "standard"
-output = "/tmp/test.log"
+output = "/tmp/test-{{.Port}}.log"
 
 [endpoints.middlewares.console_logger.options]
 format = "json"

--- a/internal/config/endpoints/middleware/logger/toml_integration_test.go
+++ b/internal/config/endpoints/middleware/logger/toml_integration_test.go
@@ -1,0 +1,97 @@
+package logger
+
+import (
+	_ "embed"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed testdata/console_logger_config.toml.tmpl
+var consoleLoggerTemplate string
+
+// TestTOMLPresetParsing proves that preset configuration is correctly parsed from TOML
+// This test will initially FAIL, proving our hypothesis that preset parsing is broken
+func TestTOMLPresetParsing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                   string
+		templateData           map[string]interface{}
+		expectedPreset         Preset
+		expectFieldsAfterApply func(fields LogOptionsHTTP) bool
+	}{
+		{
+			name: "Debug preset from TOML",
+			templateData: map[string]interface{}{
+				"Output": "/tmp/debug-test.log",
+				"Preset": "debug",
+				"Format": "json",
+				"Level":  "debug",
+			},
+			expectedPreset: PresetDebug,
+			expectFieldsAfterApply: func(fields LogOptionsHTTP) bool {
+				// Debug preset should enable all fields including request/response bodies
+				return fields.Method && fields.Path && fields.StatusCode &&
+					fields.ClientIP && fields.Duration && fields.QueryParams &&
+					fields.Protocol && fields.Host && fields.Scheme &&
+					fields.Request.Headers && fields.Response.Headers &&
+					fields.Request.Body && fields.Request.BodySize &&
+					fields.Response.Body && fields.Response.BodySize
+			},
+		},
+		{
+			name: "Minimal preset from TOML",
+			templateData: map[string]interface{}{
+				"Output": "/tmp/minimal-test.log",
+				"Preset": "minimal",
+				"Format": "json",
+				"Level":  "info",
+			},
+			expectedPreset: PresetMinimal,
+			expectFieldsAfterApply: func(fields LogOptionsHTTP) bool {
+				// Minimal preset should only enable basic fields
+				return fields.Method && fields.Path && fields.StatusCode &&
+					!fields.ClientIP && !fields.Duration && !fields.QueryParams &&
+					!fields.Request.Body && !fields.Response.Body
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Generate TOML content from template
+			tmpl, err := template.New("config").Parse(consoleLoggerTemplate)
+			require.NoError(t, err, "Template parsing should succeed")
+
+			var configBuffer strings.Builder
+			err = tmpl.Execute(&configBuffer, tt.templateData)
+			require.NoError(t, err, "Template execution should succeed")
+
+			tomlContent := configBuffer.String()
+
+			// Parse TOML into a raw structure (simulating how the config loader works)
+			var rawConfig struct {
+				ConsoleLogger ConsoleLogger `toml:"console_logger"`
+			}
+
+			err = toml.Unmarshal([]byte(tomlContent), &rawConfig)
+			require.NoError(t, err, "TOML parsing should not fail")
+
+			logger := &rawConfig.ConsoleLogger
+
+			// STEP 1: Verify preset field is correctly parsed from TOML
+			assert.Equal(t, tt.expectedPreset, logger.Preset,
+				"Preset should be parsed correctly from TOML")
+
+			// STEP 2: Verify ApplyPreset actually works when preset is set correctly
+			logger.ApplyPreset()
+			assert.True(t, tt.expectFieldsAfterApply(logger.Fields),
+				"Fields should be correctly set after ApplyPreset()")
+		})
+	}
+}

--- a/internal/config/loader/toml/postprocess.go
+++ b/internal/config/loader/toml/postprocess.go
@@ -258,9 +258,37 @@ func processConsoleLoggerConfig(
 
 	// Get the console logger config from the middleware
 	if consoleConfig := middleware.GetConsoleLogger(); consoleConfig != nil {
+		// Process preset enum if it exists
+		if presetStr, ok := consoleLoggerConfig["preset"].(string); ok {
+			var preset pbMiddleware.LogPreset
+			switch presetStr {
+			case "minimal":
+				preset = pbMiddleware.LogPreset_PRESET_MINIMAL
+			case "standard":
+				preset = pbMiddleware.LogPreset_PRESET_STANDARD
+			case "detailed":
+				preset = pbMiddleware.LogPreset_PRESET_DETAILED
+			case "debug":
+				preset = pbMiddleware.LogPreset_PRESET_DEBUG
+			default:
+				preset = pbMiddleware.LogPreset_PRESET_UNSPECIFIED
+				errList = append(
+					errList,
+					fmt.Errorf("unsupported console logger preset: %s", presetStr),
+				)
+			}
+			consoleConfig.Preset = &preset
+		}
+
 		// Process options if they exist
 		if optionsMap, ok := consoleLoggerConfig["options"].(map[string]any); ok {
 			errs := processConsoleLoggerOptions(consoleConfig, optionsMap)
+			errList = append(errList, errs...)
+		}
+
+		// Process fields if they exist
+		if fieldsMap, ok := consoleLoggerConfig["fields"].(map[string]any); ok {
+			errs := processConsoleLoggerFields(consoleConfig, fieldsMap)
 			errList = append(errList, errs...)
 		}
 	}
@@ -317,6 +345,119 @@ func processConsoleLoggerOptions(
 			errList = append(errList, fmt.Errorf("unsupported console logger level: %s", levelStr))
 		}
 		config.Options.Level = &level
+	}
+
+	return errList
+}
+
+// processConsoleLoggerFields handles field-level boolean configuration
+func processConsoleLoggerFields(
+	config *pbMiddleware.ConsoleLoggerConfig,
+	fieldsMap map[string]any,
+) []error {
+	var errList []error
+
+	// Ensure fields exist
+	if config.Fields == nil {
+		config.Fields = &pbMiddleware.LogOptionsHTTP{}
+	}
+
+	// Process HTTP field boolean settings
+	if methodVal, ok := fieldsMap["method"].(bool); ok {
+		config.Fields.Method = &methodVal
+	}
+	if pathVal, ok := fieldsMap["path"].(bool); ok {
+		config.Fields.Path = &pathVal
+	}
+	if clientIpVal, ok := fieldsMap["client_ip"].(bool); ok {
+		config.Fields.ClientIp = &clientIpVal
+	}
+	if queryParamsVal, ok := fieldsMap["query_params"].(bool); ok {
+		config.Fields.QueryParams = &queryParamsVal
+	}
+	if protocolVal, ok := fieldsMap["protocol"].(bool); ok {
+		config.Fields.Protocol = &protocolVal
+	}
+	if hostVal, ok := fieldsMap["host"].(bool); ok {
+		config.Fields.Host = &hostVal
+	}
+	if schemeVal, ok := fieldsMap["scheme"].(bool); ok {
+		config.Fields.Scheme = &schemeVal
+	}
+	if statusCodeVal, ok := fieldsMap["status_code"].(bool); ok {
+		config.Fields.StatusCode = &statusCodeVal
+	}
+	if durationVal, ok := fieldsMap["duration"].(bool); ok {
+		config.Fields.Duration = &durationVal
+	}
+
+	// Process request direction config
+	if requestMap, ok := fieldsMap["request"].(map[string]any); ok {
+		if config.Fields.Request == nil {
+			config.Fields.Request = &pbMiddleware.LogOptionsHTTP_DirectionConfig{}
+		}
+		errs := processDirectionConfig(config.Fields.Request, requestMap)
+		errList = append(errList, errs...)
+	}
+
+	// Process response direction config
+	if responseMap, ok := fieldsMap["response"].(map[string]any); ok {
+		if config.Fields.Response == nil {
+			config.Fields.Response = &pbMiddleware.LogOptionsHTTP_DirectionConfig{}
+		}
+		errs := processDirectionConfig(config.Fields.Response, responseMap)
+		errList = append(errList, errs...)
+	}
+
+	return errList
+}
+
+// processDirectionConfig handles request/response direction configuration
+func processDirectionConfig(
+	config *pbMiddleware.LogOptionsHTTP_DirectionConfig,
+	directionMap map[string]any,
+) []error {
+	var errList []error
+
+	// Process boolean fields
+	if enabledVal, ok := directionMap["enabled"].(bool); ok {
+		config.Enabled = &enabledVal
+	}
+	if bodyVal, ok := directionMap["body"].(bool); ok {
+		config.Body = &bodyVal
+	}
+	if bodySizeVal, ok := directionMap["body_size"].(bool); ok {
+		config.BodySize = &bodySizeVal
+	}
+	if headersVal, ok := directionMap["headers"].(bool); ok {
+		config.Headers = &headersVal
+	}
+
+	// Process max body size
+	if maxBodySizeVal, ok := directionMap["max_body_size"].(int); ok {
+		maxBodySize := int32(maxBodySizeVal)
+		config.MaxBodySize = &maxBodySize
+	}
+
+	// Process header include/exclude lists
+	if includeHeadersArray, ok := directionMap["include_headers"].([]any); ok {
+		var includeHeaders []string
+		for _, headerAny := range includeHeadersArray {
+			if headerStr, ok := headerAny.(string); ok {
+				includeHeaders = append(includeHeaders, headerStr)
+			}
+		}
+		config.IncludeHeaders = includeHeaders
+	}
+
+	if excludeHeadersArray, ok := directionMap["exclude_headers"].([]any); ok {
+		var excludeHeaders []string
+		for _, headerAny := range excludeHeadersArray {
+			if headerStr, ok := headerAny.(string); ok {
+				excludeHeaders = append(excludeHeaders, headerStr)
+			}
+		}
+		config.ExcludeHeaders = excludeHeaders
 	}
 
 	return errList

--- a/internal/config/loader/toml/postprocess.go
+++ b/internal/config/loader/toml/postprocess.go
@@ -260,18 +260,18 @@ func processConsoleLoggerConfig(
 	if consoleConfig := middleware.GetConsoleLogger(); consoleConfig != nil {
 		// Process preset enum if it exists
 		if presetStr, ok := consoleLoggerConfig["preset"].(string); ok {
-			var preset pbMiddleware.LogPreset
+			var preset pbMiddleware.ConsoleLoggerConfig_LogPreset
 			switch presetStr {
 			case "minimal":
-				preset = pbMiddleware.LogPreset_PRESET_MINIMAL
+				preset = pbMiddleware.ConsoleLoggerConfig_PRESET_MINIMAL
 			case "standard":
-				preset = pbMiddleware.LogPreset_PRESET_STANDARD
+				preset = pbMiddleware.ConsoleLoggerConfig_PRESET_STANDARD
 			case "detailed":
-				preset = pbMiddleware.LogPreset_PRESET_DETAILED
+				preset = pbMiddleware.ConsoleLoggerConfig_PRESET_DETAILED
 			case "debug":
-				preset = pbMiddleware.LogPreset_PRESET_DEBUG
+				preset = pbMiddleware.ConsoleLoggerConfig_PRESET_DEBUG
 			default:
-				preset = pbMiddleware.LogPreset_PRESET_UNSPECIFIED
+				preset = pbMiddleware.ConsoleLoggerConfig_PRESET_UNSPECIFIED
 				errList = append(
 					errList,
 					fmt.Errorf("unsupported console logger preset: %s", presetStr),

--- a/internal/config/loader/toml/postprocess_logger_test.go
+++ b/internal/config/loader/toml/postprocess_logger_test.go
@@ -1,6 +1,7 @@
 package toml
 
 import (
+	_ "embed"
 	"testing"
 
 	pbMiddleware "github.com/atlanticdynamic/firelynx/gen/settings/v1alpha1/middleware/v1"
@@ -10,65 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Shared TOML configuration template with manual field configuration
-const manualLoggerTOMLConfig = `
-version = "v1"
-
-[[listeners]]
-id = "http"
-address = "127.0.0.1:8080"
-type = "http"
-
-[[endpoints]]
-id = "manual-endpoint"
-listener_id = "http"
-
-[[endpoints.middlewares]]
-id = "manual-logger"
-type = "console_logger"
-
-[endpoints.middlewares.console_logger]
-output = "/tmp/manual.log"
-
-[endpoints.middlewares.console_logger.options]
-format = "json"
-level = "warn"
-
-[endpoints.middlewares.console_logger.fields]
-method = true
-path = true
-status_code = true
-client_ip = true
-duration = true
-query_params = true
-protocol = true
-host = true
-
-[endpoints.middlewares.console_logger.fields.request]
-enabled = true
-headers = true
-include_headers = ["User-Agent", "Content-Type", "Accept"]
-exclude_headers = ["Authorization", "Cookie"]
-
-[endpoints.middlewares.console_logger.fields.response]
-enabled = true
-headers = true
-body_size = true
-include_headers = ["Content-Type", "Cache-Control"]
-exclude_headers = ["Set-Cookie"]
-
-[[endpoints.routes]]
-app_id = "test-echo"
-
-[endpoints.routes.http]
-path_prefix = "/manual-test"
-
-[[apps]]
-id = "test-echo"
-
-[apps.echo]
-response = "Manual Test Response"
-`
+//go:embed testdata/manual_logger_config.toml
+var manualLoggerTOMLConfig string
 
 // TestProcessConsoleLoggerFields tests the low-level field processing function
 func TestProcessConsoleLoggerFields(t *testing.T) {

--- a/internal/config/loader/toml/postprocess_logger_test.go
+++ b/internal/config/loader/toml/postprocess_logger_test.go
@@ -1,0 +1,301 @@
+package toml
+
+import (
+	"testing"
+
+	pbMiddleware "github.com/atlanticdynamic/firelynx/gen/settings/v1alpha1/middleware/v1"
+	configLogger "github.com/atlanticdynamic/firelynx/internal/config/endpoints/middleware/logger"
+	middlewareLogger "github.com/atlanticdynamic/firelynx/internal/server/runnables/listeners/http/middleware/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Shared TOML configuration template with manual field configuration
+const manualLoggerTOMLConfig = `
+version = "v1"
+
+[[listeners]]
+id = "http"
+address = "127.0.0.1:8080"
+type = "http"
+
+[[endpoints]]
+id = "manual-endpoint"
+listener_id = "http"
+
+[[endpoints.middlewares]]
+id = "manual-logger"
+type = "console_logger"
+
+[endpoints.middlewares.console_logger]
+output = "/tmp/manual.log"
+
+[endpoints.middlewares.console_logger.options]
+format = "json"
+level = "warn"
+
+[endpoints.middlewares.console_logger.fields]
+method = true
+path = true
+status_code = true
+client_ip = true
+duration = true
+query_params = true
+protocol = true
+host = true
+
+[endpoints.middlewares.console_logger.fields.request]
+enabled = true
+headers = true
+include_headers = ["User-Agent", "Content-Type", "Accept"]
+exclude_headers = ["Authorization", "Cookie"]
+
+[endpoints.middlewares.console_logger.fields.response]
+enabled = true
+headers = true
+body_size = true
+include_headers = ["Content-Type", "Cache-Control"]
+exclude_headers = ["Set-Cookie"]
+
+[[endpoints.routes]]
+app_id = "test-echo"
+
+[endpoints.routes.http]
+path_prefix = "/manual-test"
+
+[[apps]]
+id = "test-echo"
+
+[apps.echo]
+response = "Manual Test Response"
+`
+
+// TestProcessConsoleLoggerFields tests the low-level field processing function
+func TestProcessConsoleLoggerFields(t *testing.T) {
+	config := &pbMiddleware.ConsoleLoggerConfig{}
+
+	fieldsMap := map[string]any{
+		"method":       true,
+		"path":         true,
+		"status_code":  true,
+		"client_ip":    true,
+		"duration":     true,
+		"query_params": true,
+		"protocol":     true,
+		"host":         true,
+		"request": map[string]any{
+			"enabled":         true,
+			"headers":         true,
+			"include_headers": []any{"User-Agent", "Content-Type", "Accept"},
+			"exclude_headers": []any{"Authorization", "Cookie"},
+		},
+		"response": map[string]any{
+			"enabled":         true,
+			"headers":         true,
+			"body_size":       true,
+			"include_headers": []any{"Content-Type", "Cache-Control"},
+			"exclude_headers": []any{"Set-Cookie"},
+		},
+	}
+
+	errs := processConsoleLoggerFields(config, fieldsMap)
+	require.Empty(t, errs, "Field processing should succeed")
+
+	// Verify fields were set correctly
+	require.NotNil(t, config.Fields, "Fields should be initialized")
+	assert.True(t, *config.Fields.Method, "Method should be true")
+	assert.True(t, *config.Fields.Path, "Path should be true")
+	assert.True(t, *config.Fields.StatusCode, "StatusCode should be true")
+	assert.True(t, *config.Fields.ClientIp, "ClientIp should be true")
+	assert.True(t, *config.Fields.Duration, "Duration should be true")
+	assert.True(t, *config.Fields.QueryParams, "QueryParams should be true")
+	assert.True(t, *config.Fields.Protocol, "Protocol should be true")
+	assert.True(t, *config.Fields.Host, "Host should be true")
+
+	// Verify request config
+	require.NotNil(t, config.Fields.Request, "Request config should be initialized")
+	assert.True(t, *config.Fields.Request.Enabled, "Request enabled should be true")
+	assert.True(t, *config.Fields.Request.Headers, "Request headers should be true")
+	assert.Equal(
+		t,
+		[]string{"User-Agent", "Content-Type", "Accept"},
+		config.Fields.Request.IncludeHeaders,
+	)
+	assert.Equal(t, []string{"Authorization", "Cookie"}, config.Fields.Request.ExcludeHeaders)
+
+	// Verify response config
+	require.NotNil(t, config.Fields.Response, "Response config should be initialized")
+	assert.True(t, *config.Fields.Response.Enabled, "Response enabled should be true")
+	assert.True(t, *config.Fields.Response.Headers, "Response headers should be true")
+	assert.True(t, *config.Fields.Response.BodySize, "Response body_size should be true")
+	assert.Equal(
+		t,
+		[]string{"Content-Type", "Cache-Control"},
+		config.Fields.Response.IncludeHeaders,
+	)
+	assert.Equal(t, []string{"Set-Cookie"}, config.Fields.Response.ExcludeHeaders)
+}
+
+func TestProcessConsoleLoggerFieldsEmpty(t *testing.T) {
+	config := &pbMiddleware.ConsoleLoggerConfig{}
+	fieldsMap := map[string]any{}
+
+	errs := processConsoleLoggerFields(config, fieldsMap)
+	assert.Empty(t, errs, "Empty fields should not cause errors")
+	assert.NotNil(t, config.Fields, "Fields should be initialized even when empty")
+}
+
+// TestManualLoggerTOMLIntegration tests TOML parsing to protobuf conversion
+func TestManualLoggerTOMLIntegration(t *testing.T) {
+	loader := NewTomlLoader([]byte(manualLoggerTOMLConfig))
+	config, err := loader.LoadProto()
+	require.NoError(t, err, "TOML loading should succeed")
+
+	require.NotEmpty(t, config.Endpoints, "Should have endpoints")
+	endpoint := config.Endpoints[0]
+
+	require.NotEmpty(t, endpoint.Middlewares, "Should have middlewares")
+	middleware := endpoint.Middlewares[0]
+
+	require.Equal(t, "manual-logger", middleware.GetId(), "Middleware ID should match")
+
+	consoleLogger := middleware.GetConsoleLogger()
+	require.NotNil(t, consoleLogger, "Console logger config should exist")
+
+	// Verify output and options
+	assert.Equal(t, "/tmp/manual.log", consoleLogger.GetOutput(), "Output should be set")
+	require.NotNil(t, consoleLogger.Options, "Options should be set")
+	assert.Equal(t, "FORMAT_JSON", consoleLogger.Options.Format.String(), "Format should be JSON")
+	assert.Equal(t, "LEVEL_WARN", consoleLogger.Options.Level.String(), "Level should be WARN")
+
+	// Verify fields configuration
+	require.NotNil(t, consoleLogger.Fields, "Fields should be configured")
+	assert.True(t, consoleLogger.Fields.GetMethod(), "Method should be enabled")
+	assert.True(t, consoleLogger.Fields.GetPath(), "Path should be enabled")
+	assert.True(t, consoleLogger.Fields.GetStatusCode(), "Status code should be enabled")
+	assert.True(t, consoleLogger.Fields.GetClientIp(), "Client IP should be enabled")
+	assert.True(t, consoleLogger.Fields.GetDuration(), "Duration should be enabled")
+	assert.True(t, consoleLogger.Fields.GetQueryParams(), "Query params should be enabled")
+	assert.True(t, consoleLogger.Fields.GetProtocol(), "Protocol should be enabled")
+	assert.True(t, consoleLogger.Fields.GetHost(), "Host should be enabled")
+
+	// Verify request configuration
+	request := consoleLogger.Fields.GetRequest()
+	require.NotNil(t, request, "Request config should exist")
+	assert.True(t, request.GetEnabled(), "Request should be enabled")
+	assert.True(t, request.GetHeaders(), "Request headers should be enabled")
+	assert.Equal(t, []string{"User-Agent", "Content-Type", "Accept"}, request.GetIncludeHeaders())
+	assert.Equal(t, []string{"Authorization", "Cookie"}, request.GetExcludeHeaders())
+
+	// Verify response configuration
+	response := consoleLogger.Fields.GetResponse()
+	require.NotNil(t, response, "Response config should exist")
+	assert.True(t, response.GetEnabled(), "Response should be enabled")
+	assert.True(t, response.GetHeaders(), "Response headers should be enabled")
+	assert.True(t, response.GetBodySize(), "Response body size should be enabled")
+	assert.Equal(t, []string{"Content-Type", "Cache-Control"}, response.GetIncludeHeaders())
+	assert.Equal(t, []string{"Set-Cookie"}, response.GetExcludeHeaders())
+}
+
+// TestManualLoggerEndToEnd tests the complete TOML → protobuf → domain → middleware pipeline
+func TestManualLoggerEndToEnd(t *testing.T) {
+	// Step 1: Load TOML to protobuf
+	loader := NewTomlLoader([]byte(manualLoggerTOMLConfig))
+	pbConfig, err := loader.LoadProto()
+	require.NoError(t, err, "TOML loading should succeed")
+
+	require.NotEmpty(t, pbConfig.Endpoints, "Should have endpoints")
+	endpoint := pbConfig.Endpoints[0]
+
+	require.NotEmpty(t, endpoint.Middlewares, "Should have middlewares")
+	middleware := endpoint.Middlewares[0]
+
+	consoleLoggerConfig := middleware.GetConsoleLogger()
+	require.NotNil(t, consoleLoggerConfig, "Console logger config should exist")
+
+	// Step 2: Convert protobuf to domain model
+	domainConfig, err := configLogger.FromProto(consoleLoggerConfig)
+	require.NoError(t, err, "Protobuf to domain conversion should succeed")
+
+	// Verify domain config has manual fields
+	assert.True(t, domainConfig.Fields.Method, "Domain config should have method enabled")
+	assert.True(t, domainConfig.Fields.Path, "Domain config should have path enabled")
+	assert.True(t, domainConfig.Fields.StatusCode, "Domain config should have status_code enabled")
+	assert.True(t, domainConfig.Fields.ClientIP, "Domain config should have client_ip enabled")
+	assert.True(t, domainConfig.Fields.Duration, "Domain config should have duration enabled")
+	assert.True(
+		t,
+		domainConfig.Fields.QueryParams,
+		"Domain config should have query_params enabled",
+	)
+	assert.True(t, domainConfig.Fields.Protocol, "Domain config should have protocol enabled")
+	assert.True(t, domainConfig.Fields.Host, "Domain config should have host enabled")
+
+	// Check request direction config
+	assert.True(t, domainConfig.Fields.Request.Enabled, "Request should be enabled")
+	assert.True(t, domainConfig.Fields.Request.Headers, "Request headers should be enabled")
+	assert.Equal(
+		t,
+		[]string{"User-Agent", "Content-Type", "Accept"},
+		domainConfig.Fields.Request.IncludeHeaders,
+	)
+	assert.Equal(t, []string{"Authorization", "Cookie"}, domainConfig.Fields.Request.ExcludeHeaders)
+
+	// Check response direction config
+	assert.True(t, domainConfig.Fields.Response.Enabled, "Response should be enabled")
+	assert.True(t, domainConfig.Fields.Response.Headers, "Response headers should be enabled")
+	assert.True(t, domainConfig.Fields.Response.BodySize, "Response body_size should be enabled")
+	assert.Equal(
+		t,
+		[]string{"Content-Type", "Cache-Control"},
+		domainConfig.Fields.Response.IncludeHeaders,
+	)
+	assert.Equal(t, []string{"Set-Cookie"}, domainConfig.Fields.Response.ExcludeHeaders)
+
+	// Step 3: Create middleware from domain config
+	middlewareInstance, err := middlewareLogger.NewConsoleLogger("manual-logger", domainConfig)
+	require.NoError(t, err, "Middleware creation should succeed")
+	require.NotNil(t, middlewareInstance, "Middleware should be created")
+
+	// Verify the domain config is still intact after middleware creation
+	assert.True(
+		t,
+		domainConfig.Fields.Method,
+		"Domain config should still have method enabled after middleware creation",
+	)
+	assert.True(
+		t,
+		domainConfig.Fields.Path,
+		"Domain config should still have path enabled after middleware creation",
+	)
+	assert.True(
+		t,
+		domainConfig.Fields.StatusCode,
+		"Domain config should still have status_code enabled after middleware creation",
+	)
+	assert.True(
+		t,
+		domainConfig.Fields.ClientIP,
+		"Domain config should still have client_ip enabled after middleware creation",
+	)
+	assert.True(
+		t,
+		domainConfig.Fields.Duration,
+		"Domain config should still have duration enabled after middleware creation",
+	)
+	assert.True(
+		t,
+		domainConfig.Fields.QueryParams,
+		"Domain config should still have query_params enabled after middleware creation",
+	)
+	assert.True(
+		t,
+		domainConfig.Fields.Protocol,
+		"Domain config should still have protocol enabled after middleware creation",
+	)
+	assert.True(
+		t,
+		domainConfig.Fields.Host,
+		"Domain config should still have host enabled after middleware creation",
+	)
+}

--- a/internal/config/loader/toml/testdata/manual_logger_config.toml
+++ b/internal/config/loader/toml/testdata/manual_logger_config.toml
@@ -1,0 +1,56 @@
+version = "v1"
+
+[[listeners]]
+id = "http"
+address = "127.0.0.1:8080"
+type = "http"
+
+[[endpoints]]
+id = "manual-endpoint"
+listener_id = "http"
+
+[[endpoints.middlewares]]
+id = "manual-logger"
+type = "console_logger"
+
+[endpoints.middlewares.console_logger]
+output = "/tmp/manual.log"
+
+[endpoints.middlewares.console_logger.options]
+format = "json"
+level = "warn"
+
+[endpoints.middlewares.console_logger.fields]
+method = true
+path = true
+status_code = true
+client_ip = true
+duration = true
+query_params = true
+protocol = true
+host = true
+
+[endpoints.middlewares.console_logger.fields.request]
+enabled = true
+headers = true
+include_headers = ["User-Agent", "Content-Type", "Accept"]
+exclude_headers = ["Authorization", "Cookie"]
+
+[endpoints.middlewares.console_logger.fields.response]
+enabled = true
+headers = true
+body_size = true
+include_headers = ["Content-Type", "Cache-Control"]
+exclude_headers = ["Set-Cookie"]
+
+[[endpoints.routes]]
+app_id = "test-echo"
+
+[endpoints.routes.http]
+path_prefix = "/manual-test"
+
+[[apps]]
+id = "test-echo"
+
+[apps.echo]
+response = "Manual Test Response"

--- a/internal/config/transaction/proto_test.go
+++ b/internal/config/transaction/proto_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestConfigTransaction_ToProto(t *testing.T) {
 	t.Parallel()
-	handler := logging.SetupHandlerText("debug")
+	handler := logging.SetupHandlerText("debug", nil)
 
 	t.Run("converts transaction to protobuf", func(t *testing.T) {
 		cfg := &config.Config{Version: version.Version}
@@ -238,7 +238,7 @@ func TestGetLogsVsPlaybackLogs(t *testing.T) {
 }
 
 func TestConfigTransaction_ToProto_IncludesConfig(t *testing.T) {
-	handler := logging.SetupHandlerText("debug")
+	handler := logging.SetupHandlerText("debug", nil)
 
 	t.Run("includes config when domainConfig is set", func(t *testing.T) {
 		cfg := &config.Config{Version: version.Version}

--- a/internal/interpolation/env.go
+++ b/internal/interpolation/env.go
@@ -1,6 +1,8 @@
 package interpolation
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"regexp"
 	"strings"
@@ -10,22 +12,29 @@ var envVarPattern = regexp.MustCompile(`\$\{([A-Z_][A-Z0-9_]*)\}`)
 
 // ExpandEnvVars expands environment variables in the format ${VAR_NAME}
 // Returns the string with all ${VAR_NAME} patterns replaced with their environment values
-// If an environment variable is not set, it remains as ${VAR_NAME} in the output
-func ExpandEnvVars(input string) string {
+// If an environment variable is not defined, returns an error with details of missing variables
+// Empty environment variables are treated as valid and expanded to empty strings
+func ExpandEnvVars(input string) (string, error) {
 	if input == "" {
-		return input
+		return input, nil
 	}
 
-	return envVarPattern.ReplaceAllStringFunc(input, func(match string) string {
+	var missingVars []error
+	result := envVarPattern.ReplaceAllStringFunc(input, func(match string) string {
 		// Extract variable name from ${VAR_NAME}
 		varName := strings.TrimSuffix(strings.TrimPrefix(match, "${"), "}")
 
-		// Get environment variable value
-		if value := os.Getenv(varName); value != "" {
-			return value
+		// Check if environment variable exists
+		value, exists := os.LookupEnv(varName)
+		if !exists {
+			missingVars = append(missingVars,
+				fmt.Errorf("environment variable not defined: %s", varName))
+			return match // Keep original ${VAR_NAME}
 		}
 
-		// Return original if env var not set
-		return match
+		// Return actual value (even if empty)
+		return value
 	})
+
+	return result, errors.Join(missingVars...)
 }

--- a/internal/interpolation/env.go
+++ b/internal/interpolation/env.go
@@ -1,0 +1,31 @@
+package interpolation
+
+import (
+	"os"
+	"regexp"
+	"strings"
+)
+
+var envVarPattern = regexp.MustCompile(`\$\{([A-Z_][A-Z0-9_]*)\}`)
+
+// ExpandEnvVars expands environment variables in the format ${VAR_NAME}
+// Returns the string with all ${VAR_NAME} patterns replaced with their environment values
+// If an environment variable is not set, it remains as ${VAR_NAME} in the output
+func ExpandEnvVars(input string) string {
+	if input == "" {
+		return input
+	}
+
+	return envVarPattern.ReplaceAllStringFunc(input, func(match string) string {
+		// Extract variable name from ${VAR_NAME}
+		varName := strings.TrimSuffix(strings.TrimPrefix(match, "${"), "}")
+
+		// Get environment variable value
+		if value := os.Getenv(varName); value != "" {
+			return value
+		}
+
+		// Return original if env var not set
+		return match
+	})
+}

--- a/internal/interpolation/env_test.go
+++ b/internal/interpolation/env_test.go
@@ -1,0 +1,149 @@
+package interpolation
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandEnvVars(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    string
+		envVars  map[string]string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			envVars:  nil,
+			expected: "",
+		},
+		{
+			name:     "no env vars",
+			input:    "hello world",
+			envVars:  nil,
+			expected: "hello world",
+		},
+		{
+			name:     "single env var",
+			input:    "${TEST_VAR}",
+			envVars:  map[string]string{"TEST_VAR": "test_value"},
+			expected: "test_value",
+		},
+		{
+			name:     "env var in middle",
+			input:    "prefix_${TEST_VAR}_suffix",
+			envVars:  map[string]string{"TEST_VAR": "test_value"},
+			expected: "prefix_test_value_suffix",
+		},
+		{
+			name:     "multiple env vars",
+			input:    "${VAR1}/${VAR2}/${VAR3}",
+			envVars:  map[string]string{"VAR1": "a", "VAR2": "b", "VAR3": "c"},
+			expected: "a/b/c",
+		},
+		{
+			name:     "undefined env var",
+			input:    "${UNDEFINED_VAR}",
+			envVars:  nil,
+			expected: "${UNDEFINED_VAR}",
+		},
+		{
+			name:     "mixed defined and undefined",
+			input:    "${DEFINED}/${UNDEFINED}",
+			envVars:  map[string]string{"DEFINED": "value"},
+			expected: "value/${UNDEFINED}",
+		},
+		{
+			name:     "log file path example",
+			input:    "/var/log/app-${HOSTNAME}.log",
+			envVars:  map[string]string{"HOSTNAME": "server1"},
+			expected: "/var/log/app-server1.log",
+		},
+		{
+			name:  "s3 path example",
+			input: "s3://${API_KEY}:${API_SECRET}@${BUCKET}/logs",
+			envVars: map[string]string{
+				"API_KEY":    "key123",
+				"API_SECRET": "secret456",
+				"BUCKET":     "my-bucket",
+			},
+			expected: "s3://key123:secret456@my-bucket/logs",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment variables for this test
+			for key, value := range tt.envVars {
+				require.NoError(t, os.Setenv(key, value))
+				defer func(k string) {
+					require.NoError(t, os.Unsetenv(k))
+				}(key)
+			}
+
+			result := ExpandEnvVars(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExpandEnvVarsPatternValidation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "invalid pattern single dollar",
+			input:    "$VAR",
+			expected: "$VAR",
+		},
+		{
+			name:     "invalid pattern no braces",
+			input:    "${var}",
+			expected: "${var}",
+		},
+		{
+			name:     "invalid pattern number start",
+			input:    "${1VAR}",
+			expected: "${1VAR}",
+		},
+		{
+			name:     "valid pattern with numbers",
+			input:    "${VAR_123}",
+			expected: "value",
+		},
+		{
+			name:     "valid pattern with underscores",
+			input:    "${VAR_WITH_UNDERSCORES}",
+			expected: "value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up environment variables for this test if provided
+			if tt.name == "valid pattern with numbers" {
+				require.NoError(t, os.Setenv("VAR_123", "value"))
+				defer func() {
+					require.NoError(t, os.Unsetenv("VAR_123"))
+				}()
+			}
+			if tt.name == "valid pattern with underscores" {
+				require.NoError(t, os.Setenv("VAR_WITH_UNDERSCORES", "value"))
+				defer func() {
+					require.NoError(t, os.Unsetenv("VAR_WITH_UNDERSCORES"))
+				}()
+			}
+
+			result := ExpandEnvVars(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/logging/setup.go
+++ b/internal/logging/setup.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"io"
 	"log/slog"
 	"os"
 	"strings"
@@ -8,8 +9,12 @@ import (
 	"github.com/charmbracelet/log"
 )
 
-// SetupHandlerText configures the default logger to use the provided handler
-func SetupHandlerText(logLevel string) slog.Handler {
+// SetupHandlerText configures a text slog handler with the provided writer and log level
+func SetupHandlerText(logLevel string, writer io.Writer) slog.Handler {
+	if writer == nil {
+		writer = os.Stderr
+	}
+
 	reportCaller := false
 	reportTimestamp := false
 	lvl := log.InfoLevel
@@ -29,15 +34,19 @@ func SetupHandlerText(logLevel string) slog.Handler {
 		lvl = log.ErrorLevel
 	}
 
-	return log.NewWithOptions(os.Stderr, log.Options{
+	return log.NewWithOptions(writer, log.Options{
 		ReportTimestamp: reportTimestamp,
 		ReportCaller:    reportCaller,
 		Level:           lvl,
 	})
 }
 
-// SetupHandlerJSON configures a JSON slog handler with the provided log level
-func SetupHandlerJSON(logLevel string) slog.Handler {
+// SetupHandlerJSON configures a JSON slog handler with the provided writer and log level
+func SetupHandlerJSON(logLevel string, writer io.Writer) slog.Handler {
+	if writer == nil {
+		writer = os.Stdout
+	}
+
 	reportCaller := false
 	var level slog.Level
 
@@ -63,11 +72,11 @@ func SetupHandlerJSON(logLevel string) slog.Handler {
 		AddSource: reportCaller,
 	}
 
-	return slog.NewJSONHandler(os.Stdout, opts)
+	return slog.NewJSONHandler(writer, opts)
 }
 
 // SetupLogger configures the default logger based on provided log level
 func SetupLogger(logLevel string) {
-	handler := SetupHandlerText(logLevel)
+	handler := SetupHandlerText(logLevel, nil)
 	slog.SetDefault(slog.New(handler))
 }

--- a/internal/logging/setup_test.go
+++ b/internal/logging/setup_test.go
@@ -1,0 +1,403 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupHandlerText(t *testing.T) {
+	tests := []struct {
+		name            string
+		logLevel        string
+		writer          func() *bytes.Buffer
+		expectedLevel   log.Level
+		expectCaller    bool
+		expectTimestamp bool
+	}{
+		{
+			name:            "trace level",
+			logLevel:        "trace",
+			writer:          func() *bytes.Buffer { return &bytes.Buffer{} },
+			expectedLevel:   log.DebugLevel,
+			expectCaller:    true,
+			expectTimestamp: true,
+		},
+		{
+			name:            "debug level",
+			logLevel:        "debug",
+			writer:          func() *bytes.Buffer { return &bytes.Buffer{} },
+			expectedLevel:   log.DebugLevel,
+			expectCaller:    false,
+			expectTimestamp: true,
+		},
+		{
+			name:            "info level",
+			logLevel:        "info",
+			writer:          func() *bytes.Buffer { return &bytes.Buffer{} },
+			expectedLevel:   log.InfoLevel,
+			expectCaller:    false,
+			expectTimestamp: false,
+		},
+		{
+			name:            "warn level",
+			logLevel:        "warn",
+			writer:          func() *bytes.Buffer { return &bytes.Buffer{} },
+			expectedLevel:   log.WarnLevel,
+			expectCaller:    false,
+			expectTimestamp: false,
+		},
+		{
+			name:            "warning level",
+			logLevel:        "warning",
+			writer:          func() *bytes.Buffer { return &bytes.Buffer{} },
+			expectedLevel:   log.WarnLevel,
+			expectCaller:    false,
+			expectTimestamp: false,
+		},
+		{
+			name:            "error level",
+			logLevel:        "error",
+			writer:          func() *bytes.Buffer { return &bytes.Buffer{} },
+			expectedLevel:   log.ErrorLevel,
+			expectCaller:    false,
+			expectTimestamp: false,
+		},
+		{
+			name:            "uppercase level",
+			logLevel:        "INFO",
+			writer:          func() *bytes.Buffer { return &bytes.Buffer{} },
+			expectedLevel:   log.InfoLevel,
+			expectCaller:    false,
+			expectTimestamp: false,
+		},
+		{
+			name:            "mixed case level",
+			logLevel:        "DeBuG",
+			writer:          func() *bytes.Buffer { return &bytes.Buffer{} },
+			expectedLevel:   log.DebugLevel,
+			expectCaller:    false,
+			expectTimestamp: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := tt.writer()
+			handler := SetupHandlerText(tt.logLevel, buf)
+
+			// Verify handler is created
+			require.NotNil(t, handler)
+
+			// Test logging with the handler - use appropriate level for the configured level
+			logger := slog.New(handler)
+
+			// Choose log level that will actually output based on the configured level
+			switch strings.ToLower(tt.logLevel) {
+			case "trace", "debug", "info":
+				logger.Info("test message", "key", "value")
+			case "warn", "warning":
+				logger.Warn("test message", "key", "value")
+			case "error":
+				logger.Error("test message", "key", "value")
+			default:
+				logger.Info("test message", "key", "value")
+			}
+
+			// Verify output was written
+			output := buf.String()
+			assert.NotEmpty(t, output)
+			assert.Contains(t, output, "test message")
+			assert.Contains(t, output, "key")
+			assert.Contains(t, output, "value")
+
+			// Verify timestamp presence based on level
+			if tt.expectTimestamp {
+				// For text handler, timestamp appears in various formats
+				// We just verify some time-related content is present
+				hasTimeIndicator := strings.Contains(output, "202") || // year
+					strings.Contains(output, ":") || // time separator
+					strings.Contains(output, "T") // ISO format
+				assert.True(
+					t,
+					hasTimeIndicator,
+					"Expected timestamp in output for level %s",
+					tt.logLevel,
+				)
+			}
+		})
+	}
+}
+
+func TestSetupHandlerText_NilWriter(t *testing.T) {
+	// Test that nil writer defaults to os.Stderr
+	handler := SetupHandlerText("info", nil)
+	require.NotNil(t, handler)
+
+	// We can't easily test that it uses os.Stderr without redirecting stderr,
+	// but we can verify the handler works
+	logger := slog.New(handler)
+	// This should not panic and should write to stderr
+	logger.Info("test message for stderr")
+}
+
+func TestSetupHandlerJSON(t *testing.T) {
+	tests := []struct {
+		name          string
+		logLevel      string
+		writer        func() *bytes.Buffer
+		expectedLevel slog.Level
+		expectCaller  bool
+	}{
+		{
+			name:          "trace level",
+			logLevel:      "trace",
+			writer:        func() *bytes.Buffer { return &bytes.Buffer{} },
+			expectedLevel: slog.LevelDebug,
+			expectCaller:  true,
+		},
+		{
+			name:          "debug level",
+			logLevel:      "debug",
+			writer:        func() *bytes.Buffer { return &bytes.Buffer{} },
+			expectedLevel: slog.LevelDebug,
+			expectCaller:  false,
+		},
+		{
+			name:          "info level",
+			logLevel:      "info",
+			writer:        func() *bytes.Buffer { return &bytes.Buffer{} },
+			expectedLevel: slog.LevelInfo,
+			expectCaller:  false,
+		},
+		{
+			name:          "warn level",
+			logLevel:      "warn",
+			writer:        func() *bytes.Buffer { return &bytes.Buffer{} },
+			expectedLevel: slog.LevelWarn,
+			expectCaller:  false,
+		},
+		{
+			name:          "warning level",
+			logLevel:      "warning",
+			writer:        func() *bytes.Buffer { return &bytes.Buffer{} },
+			expectedLevel: slog.LevelWarn,
+			expectCaller:  false,
+		},
+		{
+			name:          "error level",
+			logLevel:      "error",
+			writer:        func() *bytes.Buffer { return &bytes.Buffer{} },
+			expectedLevel: slog.LevelError,
+			expectCaller:  false,
+		},
+		{
+			name:          "default level (unknown)",
+			logLevel:      "unknown",
+			writer:        func() *bytes.Buffer { return &bytes.Buffer{} },
+			expectedLevel: slog.LevelInfo,
+			expectCaller:  false,
+		},
+		{
+			name:          "uppercase level",
+			logLevel:      "ERROR",
+			writer:        func() *bytes.Buffer { return &bytes.Buffer{} },
+			expectedLevel: slog.LevelError,
+			expectCaller:  false,
+		},
+		{
+			name:          "empty level defaults to info",
+			logLevel:      "",
+			writer:        func() *bytes.Buffer { return &bytes.Buffer{} },
+			expectedLevel: slog.LevelInfo,
+			expectCaller:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := tt.writer()
+			handler := SetupHandlerJSON(tt.logLevel, buf)
+
+			// Verify handler is created
+			require.NotNil(t, handler)
+
+			// Test logging with the handler - use appropriate level for the configured level
+			logger := slog.New(handler)
+
+			var expectedLevelStr string
+			switch strings.ToLower(tt.logLevel) {
+			case "trace", "debug", "info", "", "unknown":
+				logger.Info("test message", "key", "value")
+				expectedLevelStr = `"level":"INFO"`
+			case "warn", "warning":
+				logger.Warn("test message", "key", "value")
+				expectedLevelStr = `"level":"WARN"`
+			case "error":
+				logger.Error("test message", "key", "value")
+				expectedLevelStr = `"level":"ERROR"`
+			default:
+				logger.Info("test message", "key", "value")
+				expectedLevelStr = `"level":"INFO"`
+			}
+
+			// Verify JSON output was written
+			output := buf.String()
+			assert.NotEmpty(t, output)
+			assert.Contains(t, output, `"msg":"test message"`)
+			assert.Contains(t, output, `"key":"value"`)
+			assert.Contains(t, output, expectedLevelStr)
+
+			// Verify source is included for trace level
+			if tt.expectCaller {
+				assert.Contains(t, output, `"source"`)
+			}
+		})
+	}
+}
+
+func TestSetupHandlerJSON_NilWriter(t *testing.T) {
+	// Test that nil writer defaults to os.Stdout
+	handler := SetupHandlerJSON("info", nil)
+	require.NotNil(t, handler)
+
+	// We can't easily test that it uses os.Stdout without redirecting stdout,
+	// but we can verify the handler works
+	logger := slog.New(handler)
+	// This should not panic and should write to stdout
+	logger.Info("test message for stdout")
+}
+
+func TestSetupHandlerJSON_LevelFiltering(t *testing.T) {
+	// Test that log level filtering works correctly
+	buf := &bytes.Buffer{}
+	handler := SetupHandlerJSON("warn", buf)
+	logger := slog.New(handler)
+
+	// These should not appear in output
+	logger.Debug("debug message")
+	logger.Info("info message")
+
+	// These should appear in output
+	logger.Warn("warn message")
+	logger.Error("error message")
+
+	output := buf.String()
+
+	// Should not contain debug/info messages
+	assert.NotContains(t, output, "debug message")
+	assert.NotContains(t, output, "info message")
+
+	// Should contain warn/error messages
+	assert.Contains(t, output, "warn message")
+	assert.Contains(t, output, "error message")
+}
+
+func TestSetupHandlerText_LevelFiltering(t *testing.T) {
+	// Test that log level filtering works correctly for text handler
+	buf := &bytes.Buffer{}
+	handler := SetupHandlerText("error", buf)
+	logger := slog.New(handler)
+
+	// These should not appear in output
+	logger.Debug("debug message")
+	logger.Info("info message")
+	logger.Warn("warn message")
+
+	// This should appear in output
+	logger.Error("error message")
+
+	output := buf.String()
+
+	// Should not contain debug/info/warn messages
+	assert.NotContains(t, output, "debug message")
+	assert.NotContains(t, output, "info message")
+	assert.NotContains(t, output, "warn message")
+
+	// Should contain error message
+	assert.Contains(t, output, "error message")
+}
+
+func TestSetupLogger(t *testing.T) {
+	// Store original default logger to restore after test
+	originalDefault := slog.Default()
+	defer slog.SetDefault(originalDefault)
+
+	tests := []struct {
+		name     string
+		logLevel string
+	}{
+		{
+			name:     "debug level",
+			logLevel: "debug",
+		},
+		{
+			name:     "info level",
+			logLevel: "info",
+		},
+		{
+			name:     "warn level",
+			logLevel: "warn",
+		},
+		{
+			name:     "error level",
+			logLevel: "error",
+		},
+		{
+			name:     "trace level",
+			logLevel: "trace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup logger
+			SetupLogger(tt.logLevel)
+
+			// Verify default logger was changed
+			defaultLogger := slog.Default()
+			assert.NotNil(t, defaultLogger)
+
+			// Test that the logger works (this will output to stderr)
+			// We just verify it doesn't panic
+			defaultLogger.Info("test message from default logger")
+		})
+	}
+}
+
+func TestSetupLogger_Integration(t *testing.T) {
+	// Store original default logger to restore after test
+	originalDefault := slog.Default()
+	defer slog.SetDefault(originalDefault)
+
+	// Test the complete flow: setup logger and use it
+	SetupLogger("debug")
+
+	// Use the default logger that was configured
+	ctx := context.Background()
+	slog.InfoContext(ctx, "integration test message",
+		"component", "logging",
+		"test", true)
+
+	// Verify logger was set up (no panic is a good sign)
+	// The actual output goes to stderr which we can't easily capture in this test
+}
+
+func TestHandlerTypes(t *testing.T) {
+	// Test that the correct handler types are returned
+	// Factory Function Testing Pattern: Use assert.IsType() to verify concrete types
+	buf := &bytes.Buffer{}
+
+	textHandler := SetupHandlerText("info", buf)
+	jsonHandler := SetupHandlerJSON("info", buf)
+
+	// Verify they are different types
+	assert.IsType(t, &log.Logger{}, textHandler)
+	assert.IsType(t, &slog.JSONHandler{}, jsonHandler)
+}

--- a/internal/logging/writers/writers.go
+++ b/internal/logging/writers/writers.go
@@ -1,0 +1,82 @@
+package writers
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// WriterType represents the type of writer to create
+type WriterType string
+
+const (
+	WriterTypeStdout WriterType = "stdout"
+	WriterTypeStderr WriterType = "stderr"
+	WriterTypeFile   WriterType = "file"
+)
+
+// CreateWriter creates an io.Writer based on the output specification
+// Supported formats:
+//   - "stdout" or "" - writes to os.Stdout
+//   - "stderr" - writes to os.Stderr
+//   - "file:/path/to/file" - writes to file (creates directories if needed)
+//   - "/path/to/file" - writes to file (creates directories if needed)
+func CreateWriter(output string) (io.Writer, error) {
+	switch {
+	case output == "" || output == "stdout":
+		return os.Stdout, nil
+	case output == "stderr":
+		return os.Stderr, nil
+	case strings.HasPrefix(output, "file://"):
+		filePath := strings.TrimPrefix(output, "file://")
+		return createFileWriter(filePath)
+	case isFilePath(output):
+		// Direct file path
+		return createFileWriter(output)
+	default:
+		return nil, fmt.Errorf("unsupported output format: %s", output)
+	}
+}
+
+// isFilePath determines if the string represents a local file path
+func isFilePath(path string) bool {
+	// Reject URLs with schemes other than file://
+	if strings.Contains(path, "://") && !strings.HasPrefix(path, "file://") {
+		return false
+	}
+
+	// Check for path-like patterns
+	return strings.Contains(path, "/") || strings.Contains(path, "\\")
+}
+
+// createFileWriter creates a file writer, ensuring the directory exists
+func createFileWriter(filePath string) (io.Writer, error) {
+	// Create directory if it doesn't exist
+	dir := filepath.Dir(filePath)
+	if dir != "." && dir != "/" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("failed to create directory %s: %w", dir, err)
+		}
+	}
+
+	// Open file for writing (create if not exists, append if exists)
+	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %s: %w", filePath, err)
+	}
+
+	return file, nil
+}
+
+// ParseWriterType determines the writer type from an output string
+func ParseWriterType(output string) WriterType {
+	if output == "" || output == "stdout" {
+		return WriterTypeStdout
+	}
+	if output == "stderr" {
+		return WriterTypeStderr
+	}
+	return WriterTypeFile
+}

--- a/internal/logging/writers/writers_test.go
+++ b/internal/logging/writers/writers_test.go
@@ -1,0 +1,192 @@
+package writers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateWriter(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		output     string
+		wantType   WriterType
+		shouldFail bool
+	}{
+		{
+			name:     "empty string defaults to stdout",
+			output:   "",
+			wantType: WriterTypeStdout,
+		},
+		{
+			name:     "stdout",
+			output:   "stdout",
+			wantType: WriterTypeStdout,
+		},
+		{
+			name:     "stderr",
+			output:   "stderr",
+			wantType: WriterTypeStderr,
+		},
+		{
+			name:     "file path",
+			output:   "/tmp/test.log",
+			wantType: WriterTypeFile,
+		},
+		{
+			name:     "file protocol",
+			output:   "file:///tmp/test.log",
+			wantType: WriterTypeFile,
+		},
+		{
+			name:       "unsupported format",
+			output:     "redis://localhost:6379",
+			shouldFail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writer, err := CreateWriter(tt.output)
+
+			if tt.shouldFail {
+				assert.Error(t, err)
+				assert.Nil(t, writer)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, writer)
+
+			// Verify writer type by checking the underlying type
+			switch tt.wantType {
+			case WriterTypeStdout:
+				assert.Equal(t, os.Stdout, writer)
+			case WriterTypeStderr:
+				assert.Equal(t, os.Stderr, writer)
+			case WriterTypeFile:
+				// For file writers, just verify it's not stdout/stderr
+				assert.NotEqual(t, os.Stdout, writer)
+				assert.NotEqual(t, os.Stderr, writer)
+			}
+		})
+	}
+}
+
+func TestCreateFileWriter(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name     string
+		filePath string
+		setup    func() error
+		cleanup  func() error
+	}{
+		{
+			name:     "create file in existing directory",
+			filePath: filepath.Join(tmpDir, "test.log"),
+		},
+		{
+			name:     "create file with nested directories",
+			filePath: filepath.Join(tmpDir, "nested", "dir", "test.log"),
+		},
+		{
+			name:     "append to existing file",
+			filePath: filepath.Join(tmpDir, "existing.log"),
+			setup: func() error {
+				return os.WriteFile(
+					filepath.Join(tmpDir, "existing.log"),
+					[]byte("existing content\n"),
+					0o644,
+				)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = ctx
+
+			if tt.setup != nil {
+				require.NoError(t, tt.setup())
+			}
+
+			writer, err := createFileWriter(tt.filePath)
+			require.NoError(t, err)
+			require.NotNil(t, writer)
+
+			// Test writing to the file
+			testContent := "test content\n"
+			n, err := writer.Write([]byte(testContent))
+			require.NoError(t, err)
+			assert.Equal(t, len(testContent), n)
+
+			// Verify file exists and has content
+			content, err := os.ReadFile(tt.filePath)
+			require.NoError(t, err)
+			assert.Contains(t, string(content), testContent)
+
+			// Close the file if it implements io.Closer
+			if closer, ok := writer.(interface{ Close() error }); ok {
+				require.NoError(t, closer.Close())
+			}
+
+			if tt.cleanup != nil {
+				require.NoError(t, tt.cleanup())
+			}
+		})
+	}
+}
+
+func TestParseWriterType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		output   string
+		expected WriterType
+	}{
+		{
+			name:     "empty string",
+			output:   "",
+			expected: WriterTypeStdout,
+		},
+		{
+			name:     "stdout",
+			output:   "stdout",
+			expected: WriterTypeStdout,
+		},
+		{
+			name:     "stderr",
+			output:   "stderr",
+			expected: WriterTypeStderr,
+		},
+		{
+			name:     "file path",
+			output:   "/var/log/app.log",
+			expected: WriterTypeFile,
+		},
+		{
+			name:     "file protocol",
+			output:   "file:///var/log/app.log",
+			expected: WriterTypeFile,
+		},
+		{
+			name:     "relative file path",
+			output:   "./logs/app.log",
+			expected: WriterTypeFile,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseWriterType(tt.output)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/server/integration_tests/http/logger_integration_test.go
+++ b/internal/server/integration_tests/http/logger_integration_test.go
@@ -1,0 +1,557 @@
+//go:build integration
+
+package http_test
+
+import (
+	"bufio"
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/atlanticdynamic/firelynx/internal/config"
+	"github.com/atlanticdynamic/firelynx/internal/config/transaction"
+	"github.com/atlanticdynamic/firelynx/internal/logging"
+	httplistener "github.com/atlanticdynamic/firelynx/internal/server/runnables/listeners/http"
+	"github.com/atlanticdynamic/firelynx/internal/server/runnables/txmgr/orchestrator"
+	"github.com/atlanticdynamic/firelynx/internal/server/runnables/txmgr/txstorage"
+	"github.com/atlanticdynamic/firelynx/internal/testutil"
+	"github.com/stretchr/testify/suite"
+)
+
+//go:embed testdata/logger_integration.toml.tmpl
+var loggerIntegrationTemplate string
+
+// LogEntry represents the structure of JSON log entries
+type LogEntry struct {
+	Time  string `json:"time"`
+	Level string `json:"level"`
+	Msg   string `json:"msg"`
+	HTTP  struct {
+		Method      string                 `json:"method,omitempty"`
+		Path        string                 `json:"path,omitempty"`
+		StatusCode  int                    `json:"status,omitempty"`
+		ClientIP    string                 `json:"client_ip,omitempty"`
+		Duration    int                    `json:"duration,omitempty"`
+		Query       string                 `json:"query,omitempty"`        // Query string as used by logger
+		QueryParams map[string]interface{} `json:"query_params,omitempty"` // Keep for backward compatibility
+		Protocol    string                 `json:"protocol,omitempty"`
+		Host        string                 `json:"host,omitempty"`
+		Scheme      string                 `json:"scheme,omitempty"`
+		UserAgent   string                 `json:"user_agent,omitempty"`
+		BodySize    *int                   `json:"body_size,omitempty"`
+		Request     struct {
+			Headers map[string][]string `json:"headers,omitempty"`
+		} `json:"request,omitempty"`
+		Response struct {
+			Headers map[string][]string `json:"headers,omitempty"`
+		} `json:"response,omitempty"`
+	} `json:"http,omitempty"`
+}
+
+type LoggerIntegrationTestSuite struct {
+	suite.Suite
+	ctx         context.Context
+	cancel      context.CancelFunc
+	tempDir     string
+	envLogDir   string
+	port        int
+	logFile     string
+	httpRunner  *httplistener.Runner
+	saga        *orchestrator.SagaOrchestrator
+	originalEnv map[string]string
+	runnerErrCh chan error
+}
+
+func (s *LoggerIntegrationTestSuite) SetupSuite() {
+	// Setup debug logging for better test debugging
+	logging.SetupLogger("debug")
+
+	s.ctx, s.cancel = context.WithCancel(s.T().Context())
+	s.tempDir = s.T().TempDir()
+	s.port = testutil.GetRandomPort(s.T())
+	s.logFile = filepath.Join(s.tempDir, "firelynx.log")
+	s.runnerErrCh = make(chan error, 1)
+
+	// Set environment variables for environment variable interpolation testing
+	s.envLogDir = filepath.Join(s.tempDir, "env_logs")
+	err := os.MkdirAll(s.envLogDir, 0o755)
+	s.Require().NoError(err, "Failed to create env log directory")
+
+	s.originalEnv = map[string]string{
+		"FIRELYNX_LOG_DIR": os.Getenv("FIRELYNX_LOG_DIR"),
+		"HOSTNAME":         os.Getenv("HOSTNAME"),
+		"TEST_SESSION":     os.Getenv("TEST_SESSION"),
+	}
+
+	// Set test environment variables
+	os.Setenv("FIRELYNX_LOG_DIR", s.envLogDir)
+	os.Setenv("HOSTNAME", "test-host")
+	os.Setenv("TEST_SESSION", "session-123")
+
+	// Template variables
+	templateVars := struct {
+		Port    int
+		LogFile string
+	}{
+		Port:    s.port,
+		LogFile: s.logFile,
+	}
+
+	// Render the configuration template
+	tmpl, err := template.New("config").Parse(loggerIntegrationTemplate)
+	s.Require().NoError(err, "Failed to parse config template")
+
+	var configBuffer strings.Builder
+	err = tmpl.Execute(&configBuffer, templateVars)
+	s.Require().NoError(err, "Failed to render config template")
+
+	configData := configBuffer.String()
+	s.T().Logf("Rendered config:\n%s", configData)
+
+	// Load and validate the configuration
+	cfg, err := config.NewConfigFromBytes([]byte(configData))
+	s.Require().NoError(err, "Failed to load config")
+	s.Require().NoError(cfg.Validate(), "Config validation failed")
+
+	// Create transaction storage
+	txStore := txstorage.NewMemoryStorage()
+
+	// Create saga orchestrator
+	s.saga = orchestrator.NewSagaOrchestrator(txStore, slog.Default().Handler())
+
+	// Create HTTP runner
+	s.httpRunner, err = httplistener.NewRunner()
+	s.Require().NoError(err)
+
+	// Register HTTP runner with orchestrator
+	err = s.saga.RegisterParticipant(s.httpRunner)
+	s.Require().NoError(err)
+
+	// Start the HTTP runner
+	go func() {
+		s.runnerErrCh <- s.httpRunner.Run(s.ctx)
+	}()
+
+	// Wait for runner to start with error checking
+	s.Require().Eventually(func() bool {
+		select {
+		case err := <-s.runnerErrCh:
+			s.T().Fatalf("HTTP runner failed to start: %v", err)
+			return false
+		default:
+			return s.httpRunner.IsRunning()
+		}
+	}, time.Second, 10*time.Millisecond, "HTTP runner should start")
+
+	// Create a config transaction
+	tx, err := transaction.FromTest(s.T().Name(), cfg, nil)
+	s.Require().NoError(err)
+
+	// Validate the transaction
+	err = tx.RunValidation()
+	s.Require().NoError(err)
+
+	// Process the transaction through the orchestrator
+	err = s.saga.ProcessTransaction(s.ctx, tx)
+	s.Require().NoError(err)
+
+	// Verify the transaction completed successfully
+	s.Require().Equal("completed", tx.GetState())
+
+	// Wait for the server to be fully ready
+	s.Require().Eventually(func() bool {
+		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/test", s.port))
+		if err != nil {
+			return false
+		}
+		resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 10*time.Second, 100*time.Millisecond, "Server should be ready to accept requests")
+}
+
+func (s *LoggerIntegrationTestSuite) TearDownSuite() {
+	// Cancel context to signal shutdown
+	if s.cancel != nil {
+		s.cancel()
+	}
+
+	// Stop HTTP runner if it exists
+	if s.httpRunner != nil {
+		s.httpRunner.Stop()
+
+		// Wait for runner to stop
+		s.Require().Eventually(func() bool {
+			return !s.httpRunner.IsRunning()
+		}, time.Second, 10*time.Millisecond, "HTTP runner should stop")
+
+		// Wait for background goroutine to complete
+		select {
+		case err := <-s.runnerErrCh:
+			if err != nil && err != context.Canceled {
+				s.T().Logf("HTTP runner exited with error: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			s.T().Log("Timeout waiting for HTTP runner goroutine to complete")
+		}
+	}
+
+	// Restore environment variables
+	for key, value := range s.originalEnv {
+		if value == "" {
+			os.Unsetenv(key)
+		} else {
+			os.Setenv(key, value)
+		}
+	}
+}
+
+func (s *LoggerIntegrationTestSuite) TestStandardLogger() {
+	// Make a request to generate logs
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/test", s.port))
+	s.Require().NoError(err, "Failed to make request")
+	defer resp.Body.Close()
+
+	s.Require().Equal(http.StatusOK, resp.StatusCode, "Expected 200 OK")
+
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err, "Failed to read response body")
+	s.Contains(
+		string(body),
+		"Integration Test Response",
+		"Response should contain expected text",
+	)
+
+	var logEntries []LogEntry
+	s.Eventually(func() bool {
+		logEntries = s.readLogEntries(s.logFile)
+		return len(logEntries) > 0
+	}, 5*time.Second, 100*time.Millisecond, "Log file should contain entries")
+
+	// Find our test request log entry
+	var testEntry *LogEntry
+	for _, entry := range logEntries {
+		if entry.HTTP.Path == "/test" && entry.HTTP.Method == "GET" {
+			testEntry = &entry
+			break
+		}
+	}
+	s.Require().NotNil(testEntry, "Should find log entry for /test request")
+
+	// Verify standard preset fields are present
+	s.Equal("GET", testEntry.HTTP.Method, "Method should be logged")
+	s.Equal("/test", testEntry.HTTP.Path, "Path should be logged")
+	s.Equal(200, testEntry.HTTP.StatusCode, "Status code should be logged")
+	s.NotEmpty(testEntry.HTTP.ClientIP, "Client IP should be logged")
+	s.NotZero(testEntry.HTTP.Duration, "Duration should be logged")
+	s.Equal("INFO", testEntry.Level, "Log level should be info")
+
+	s.T().Logf("Standard log entry: %+v", testEntry)
+}
+
+func (s *LoggerIntegrationTestSuite) TestEnvironmentVariableLogger() {
+	envLogFile := filepath.Join(s.envLogDir, "access-test-host.log")
+
+	// Make a request with query parameters and headers to test detailed preset
+	client := &http.Client{}
+	req, err := http.NewRequest(
+		"GET",
+		fmt.Sprintf("http://127.0.0.1:%d/env-test?debug=true", s.port),
+		nil,
+	)
+	s.Require().NoError(err, "Failed to create request")
+
+	req.Header.Set("User-Agent", "FireLynx-EnvTest/1.0")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	s.Require().NoError(err, "Failed to make request")
+	defer resp.Body.Close()
+
+	var logEntries []LogEntry
+	s.Eventually(func() bool {
+		logEntries = s.readLogEntries(envLogFile)
+		for _, entry := range logEntries {
+			if entry.HTTP.Path == "/env-test" && entry.HTTP.Method == "GET" {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 100*time.Millisecond, "Environment variable log file should contain /env-test entry")
+
+	// Find our test request log entry
+	var testEntry *LogEntry
+	for _, entry := range logEntries {
+		if entry.HTTP.Path == "/env-test" && entry.HTTP.Method == "GET" {
+			testEntry = &entry
+			break
+		}
+	}
+	s.Require().NotNil(testEntry, "Should find log entry for /env-test request")
+
+	// Verify detailed preset fields are present (from env-logger config)
+	s.Equal("GET", testEntry.HTTP.Method, "Method should be logged")
+	s.Equal("/env-test", testEntry.HTTP.Path, "Path should be logged")
+	s.NotEmpty(testEntry.HTTP.Query, "Query string should be logged with detailed preset")
+	s.NotEmpty(testEntry.HTTP.Protocol, "Protocol should be logged with detailed preset")
+	s.NotEmpty(testEntry.HTTP.Host, "Host should be logged with detailed preset")
+	s.Equal(
+		"INFO",
+		testEntry.Level,
+		"Log level should be info for successful requests (status 200)",
+	)
+
+	// Verify query parameters were captured
+	s.Contains(testEntry.HTTP.Query, "debug=true", "Should contain debug parameter")
+
+	s.T().Logf("Environment variable log entry: %+v", testEntry)
+}
+
+func (s *LoggerIntegrationTestSuite) TestMinimalLogger() {
+	logFile := s.logFile + ".minimal"
+
+	// Make a request to test minimal preset
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/minimal-test", s.port))
+	s.Require().NoError(err, "Failed to make request")
+	defer resp.Body.Close()
+
+	var logEntries []LogEntry
+	s.Eventually(func() bool {
+		logEntries = s.readLogEntries(logFile)
+		for _, entry := range logEntries {
+			if entry.HTTP.Path == "/minimal-test" {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 100*time.Millisecond, "Minimal log file should contain /minimal-test entry")
+
+	// Find our test request log entry
+	var testEntry *LogEntry
+	for _, entry := range logEntries {
+		if entry.HTTP.Path == "/minimal-test" {
+			testEntry = &entry
+			break
+		}
+	}
+	s.Require().NotNil(testEntry, "Should find log entry for /minimal-test request")
+
+	// Verify minimal preset fields only (method, path, status_code)
+	s.Equal("GET", testEntry.HTTP.Method, "Minimal preset should include method")
+	s.Equal("/minimal-test", testEntry.HTTP.Path, "Minimal preset should include path")
+	s.Equal(200, testEntry.HTTP.StatusCode, "Minimal preset should include status_code")
+
+	// Verify minimal preset excludes detailed fields
+	s.Empty(testEntry.HTTP.ClientIP, "Minimal preset should NOT include client_ip")
+	s.Zero(testEntry.HTTP.Duration, "Minimal preset should NOT include duration")
+	s.Nil(testEntry.HTTP.QueryParams, "Minimal preset should NOT include query_params")
+
+	s.T().Logf("Minimal log entry: %+v", testEntry)
+}
+
+func (s *LoggerIntegrationTestSuite) TestManualLogger() {
+	logFile := filepath.Join(s.envLogDir, "manual-session-123.log")
+
+	// Make a request with various headers to test manual field configuration
+	client := &http.Client{}
+	req, err := http.NewRequest(
+		"POST",
+		fmt.Sprintf("http://127.0.0.1:%d/manual-test?test=manual", s.port),
+		nil,
+	)
+	s.Require().NoError(err, "Failed to create request")
+
+	req.Header.Set("User-Agent", "FireLynx-ManualTest/1.0")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer should-be-excluded")
+	req.Header.Set("Cookie", "session=should-be-excluded")
+
+	resp, err := client.Do(req)
+	s.Require().NoError(err, "Failed to make request")
+	defer resp.Body.Close()
+
+	var logEntries []LogEntry
+	s.Eventually(func() bool {
+		logEntries = s.readLogEntries(logFile)
+		for _, entry := range logEntries {
+			if entry.HTTP.Path == "/manual-test" && entry.HTTP.Method == "POST" {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 100*time.Millisecond, "Manual log file should contain /manual-test entry")
+
+	// Find our test request log entry
+	var testEntry *LogEntry
+	for _, entry := range logEntries {
+		if entry.HTTP.Path == "/manual-test" && entry.HTTP.Method == "POST" {
+			testEntry = &entry
+			break
+		}
+	}
+	s.Require().NotNil(testEntry, "Should find log entry for /manual-test request")
+
+	// Verify manual configuration fields
+	s.Equal("POST", testEntry.HTTP.Method, "Manual config should include method")
+	s.Equal("/manual-test", testEntry.HTTP.Path, "Manual config should include path")
+	s.Equal(200, testEntry.HTTP.StatusCode, "Manual config should include status_code")
+	s.NotEmpty(testEntry.HTTP.ClientIP, "Manual config should include client_ip")
+	s.NotZero(testEntry.HTTP.Duration, "Manual config should include duration")
+	s.NotEmpty(testEntry.HTTP.Query, "Manual config should include query string")
+	s.NotEmpty(testEntry.HTTP.Protocol, "Manual config should include protocol")
+	s.NotEmpty(testEntry.HTTP.Host, "Manual config should include host")
+	s.Equal(
+		"INFO",
+		testEntry.Level,
+		"Log level should be info for successful requests (status 200)",
+	)
+
+	s.T().Logf("Manual configuration log entry: %+v", testEntry)
+}
+
+func (s *LoggerIntegrationTestSuite) TestPresetFunctionality() {
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/preset-test", s.port))
+	s.Require().NoError(err, "Failed to make request")
+	defer resp.Body.Close()
+
+	var logEntries []LogEntry
+	s.Eventually(func() bool {
+		logEntries = s.readLogEntries(s.logFile)
+		for _, entry := range logEntries {
+			if entry.HTTP.Path == "/preset-test" {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 100*time.Millisecond, "Log file should contain /preset-test entry")
+
+	var testEntry *LogEntry
+	for _, entry := range logEntries {
+		if entry.HTTP.Path == "/preset-test" {
+			testEntry = &entry
+			break
+		}
+	}
+	s.Require().NotNil(testEntry, "Should find log entry for /preset-test request")
+
+	s.NotEmpty(testEntry.HTTP.Method, "Standard preset should include method")
+	s.NotEmpty(testEntry.HTTP.Path, "Standard preset should include path")
+	s.NotZero(testEntry.HTTP.StatusCode, "Standard preset should include status_code")
+	s.NotEmpty(testEntry.HTTP.ClientIP, "Standard preset should include client_ip")
+	s.NotZero(testEntry.HTTP.Duration, "Standard preset should include duration")
+}
+
+func (s *LoggerIntegrationTestSuite) TestPathFiltering() {
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/health", s.port))
+	s.Require().NoError(err, "Failed to make request")
+	defer resp.Body.Close()
+
+	resp2, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/normal", s.port))
+	s.Require().NoError(err, "Failed to make request")
+	defer resp2.Body.Close()
+
+	var logEntries []LogEntry
+	s.Eventually(func() bool {
+		logEntries = s.readLogEntries(s.logFile)
+		for _, entry := range logEntries {
+			if entry.HTTP.Path == "/normal" {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 100*time.Millisecond, "Log file should contain /normal entry")
+
+	healthLogged := false
+	normalLogged := false
+
+	for _, entry := range logEntries {
+		if entry.HTTP.Path == "/health" {
+			healthLogged = true
+		}
+		if entry.HTTP.Path == "/normal" {
+			normalLogged = true
+		}
+	}
+
+	s.False(healthLogged, "/health should be filtered out by exclude_paths")
+	s.True(normalLogged, "/normal should be logged")
+}
+
+func (s *LoggerIntegrationTestSuite) TestEnvironmentVariableInterpolation() {
+	// Test that environment variables were properly interpolated by checking file existence
+	expectedFiles := []string{
+		"access-test-host.log",   // From ${FIRELYNX_LOG_DIR}/access-${HOSTNAME}.log
+		"manual-session-123.log", // From ${FIRELYNX_LOG_DIR}/manual-${TEST_SESSION}.log
+	}
+
+	// Make a request to ensure the loggers create the files
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/env-interpolation-test", s.port))
+	s.Require().NoError(err, "Failed to make request")
+	resp.Body.Close()
+
+	for _, expectedFile := range expectedFiles {
+		filePath := filepath.Join(s.envLogDir, expectedFile)
+
+		s.Eventually(func() bool {
+			_, err := os.Stat(filePath)
+			return err == nil
+		}, 5*time.Second, 100*time.Millisecond, "Environment variable interpolated log file should exist: %s", expectedFile)
+
+		s.T().Logf("Environment variable interpolated file exists: %s", filePath)
+	}
+}
+
+// Helper function to read and parse log entries from a file
+func (s *LoggerIntegrationTestSuite) readLogEntries(logFilePath string) []LogEntry {
+	file, err := os.Open(logFilePath)
+	if err != nil {
+		s.T().Logf("Log file %s does not exist or cannot be opened: %v", logFilePath, err)
+		return nil
+	}
+	defer file.Close()
+
+	var entries []LogEntry
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		s.T().Logf("Raw JSON line: %s", line)
+
+		var entry LogEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			s.T().Logf("Failed to parse JSON log line: %s, error: %v", line, err)
+			continue
+		}
+
+		entries = append(entries, entry)
+	}
+
+	if err := scanner.Err(); err != nil {
+		s.T().Logf("Error reading log file: %v", err)
+	}
+
+	s.T().Logf("Read %d log entries from %s", len(entries), logFilePath)
+	for i, entry := range entries {
+		s.T().
+			Logf("Entry %d: Method=%s, Path=%s, Msg=%s", i+1, entry.HTTP.Method, entry.HTTP.Path, entry.Msg)
+	}
+	return entries
+}
+
+func TestLoggerIntegrationSuite(t *testing.T) {
+	suite.Run(t, new(LoggerIntegrationTestSuite))
+}

--- a/internal/server/integration_tests/http/middleware_logging_test.go
+++ b/internal/server/integration_tests/http/middleware_logging_test.go
@@ -62,7 +62,8 @@ func TestLoggingConfigurationPipeline(t *testing.T) {
 		)
 
 		// Create the middleware with the loaded config
-		consoleLogger := logger.NewConsoleLogger("test-logger", consoleLoggerConfig)
+		consoleLogger, err := logger.NewConsoleLogger("test-logger", consoleLoggerConfig)
+		require.NoError(t, err, "should create console logger without error")
 		require.NotNil(t, consoleLogger, "console logger should be created")
 
 		// Test that the middleware actually logs in JSON format using loglater
@@ -70,7 +71,7 @@ func TestLoggingConfigurationPipeline(t *testing.T) {
 		logCollector := loglater.NewLogCollector(nil)
 
 		// Create a new console logger with our collector as the handler
-		jsonHandler := centralLogger.SetupHandlerJSON("info")
+		jsonHandler := centralLogger.SetupHandlerJSON("info", nil)
 		testLogger := slog.New(logCollector).WithGroup("http")
 
 		// Create a context and test log entry
@@ -136,11 +137,11 @@ func TestLoggingConfigurationPipeline(t *testing.T) {
 
 	t.Run("verifies handler selection logic", func(t *testing.T) {
 		// Test JSON handler creation directly
-		jsonHandler := centralLogger.SetupHandlerJSON("info")
+		jsonHandler := centralLogger.SetupHandlerJSON("info", nil)
 		require.NotNil(t, jsonHandler, "JSON handler should be created")
 
 		// Test text handler creation directly
-		textHandler := centralLogger.SetupHandlerText("info")
+		textHandler := centralLogger.SetupHandlerText("info", nil)
 		require.NotNil(t, textHandler, "text handler should be created")
 
 		// They should be different types

--- a/internal/server/integration_tests/http/single_logger_debug_test.go
+++ b/internal/server/integration_tests/http/single_logger_debug_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+
+package http_test
+
+import (
+	_ "embed"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/atlanticdynamic/firelynx/internal/config"
+	"github.com/atlanticdynamic/firelynx/internal/config/transaction"
+	httplistener "github.com/atlanticdynamic/firelynx/internal/server/runnables/listeners/http"
+	"github.com/atlanticdynamic/firelynx/internal/server/runnables/txmgr/orchestrator"
+	"github.com/atlanticdynamic/firelynx/internal/server/runnables/txmgr/txstorage"
+	"github.com/atlanticdynamic/firelynx/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed testdata/single_logger.toml.tmpl
+var singleLoggerTemplate string
+
+func TestSingleLoggerFileOutput(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	tempDir := t.TempDir()
+	port := testutil.GetRandomPort(t)
+	logFile := filepath.Join(tempDir, "single.log")
+
+	templateVars := struct {
+		Port    int
+		LogFile string
+	}{
+		Port:    port,
+		LogFile: logFile,
+	}
+
+	tmpl, err := template.New("config").Parse(singleLoggerTemplate)
+	require.NoError(t, err)
+
+	var configBuffer strings.Builder
+	err = tmpl.Execute(&configBuffer, templateVars)
+	require.NoError(t, err)
+
+	configData := configBuffer.String()
+	t.Logf("Config:\n%s", configData)
+
+	cfg, err := config.NewConfigFromBytes([]byte(configData))
+	require.NoError(t, err)
+	require.NoError(t, cfg.Validate())
+
+	txStore := txstorage.NewMemoryStorage()
+	saga := orchestrator.NewSagaOrchestrator(txStore, slog.Default().Handler())
+
+	httpRunner, err := httplistener.NewRunner()
+	require.NoError(t, err)
+
+	err = saga.RegisterParticipant(httpRunner)
+	require.NoError(t, err)
+
+	runnerErrCh := make(chan error, 1)
+	go func() {
+		runnerErrCh <- httpRunner.Run(ctx)
+	}()
+
+	require.Eventually(t, func() bool {
+		return httpRunner.IsRunning()
+	}, time.Second, 10*time.Millisecond)
+
+	tx, err := transaction.FromTest(t.Name(), cfg, nil)
+	require.NoError(t, err)
+
+	err = tx.RunValidation()
+	require.NoError(t, err)
+
+	err = saga.ProcessTransaction(ctx, tx)
+	require.NoError(t, err)
+
+	require.Equal(t, "completed", tx.GetState())
+
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/debug-test", port))
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 10*time.Second, 100*time.Millisecond)
+
+	assert.Eventually(t, func() bool {
+		info, err := os.Stat(logFile)
+		return err == nil && info.Size() > 0
+	}, 5*time.Second, 100*time.Millisecond)
+
+	content, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	t.Logf("Log content:\n%s", string(content))
+
+	httpRunner.Stop()
+	require.Eventually(t, func() bool {
+		return !httpRunner.IsRunning()
+	}, time.Second, 10*time.Millisecond)
+}

--- a/internal/server/integration_tests/http/testdata/logger_integration.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/logger_integration.toml.tmpl
@@ -238,3 +238,129 @@ response = "Normal Test Response"
 id = "test-echo-env-interpolation"
 [apps.echo]
 response = "Environment Interpolation Test Response"
+
+# Text Format Endpoint with Standard Preset
+[[endpoints]]
+id = "text-standard"
+listener_id = "http"
+
+[[endpoints.middlewares]]
+id = "text-standard-logger"
+type = "console_logger"
+
+[endpoints.middlewares.console_logger]
+preset = "standard"
+output = "{{.LogFile}}.text-standard.log"
+
+[endpoints.middlewares.console_logger.options]
+format = "txt"                         # Text format instead of JSON
+level = "info"
+
+[[endpoints.routes]]
+app_id = "text-echo-standard"
+[endpoints.routes.http]
+path_prefix = "/text-standard"
+
+# Text Format Endpoint with Detailed Preset
+[[endpoints]]
+id = "text-detailed"
+listener_id = "http"
+
+[[endpoints.middlewares]]
+id = "text-detailed-logger"
+type = "console_logger"
+
+[endpoints.middlewares.console_logger]
+preset = "detailed"
+output = "{{.LogFile}}.text-detailed.log"
+
+[endpoints.middlewares.console_logger.options]
+format = "txt"
+level = "debug"
+
+[[endpoints.routes]]
+app_id = "text-echo-detailed"
+[endpoints.routes.http]
+path_prefix = "/text-detailed"
+
+[[apps]]
+id = "text-echo-standard"
+[apps.echo]
+response = "Text Standard Response"
+
+[[apps]]
+id = "text-echo-detailed"
+[apps.echo]
+response = "Text Detailed Response"
+
+# Multiple Middleware Per Endpoint Test
+[[endpoints]]
+id = "multi-middleware-endpoint"
+listener_id = "http"
+
+# Logger for GET requests only
+[[endpoints.middlewares]]
+id = "get-only-logger"
+type = "console_logger"
+
+[endpoints.middlewares.console_logger]
+include_only_methods = ["GET"]
+output = "{{.LogFile}}.get-only.log"
+preset = "minimal"
+
+[endpoints.middlewares.console_logger.options]
+format = "json"
+level = "info"
+
+# Logger for POST requests only
+[[endpoints.middlewares]]
+id = "post-only-logger"
+type = "console_logger"
+
+[endpoints.middlewares.console_logger]
+include_only_methods = ["POST"]
+output = "{{.LogFile}}.post-only.log"
+preset = "detailed"
+
+[endpoints.middlewares.console_logger.options]
+format = "json"
+level = "debug"
+
+[[endpoints.routes]]
+app_id = "multi-middleware-echo"
+[endpoints.routes.http]
+path_prefix = "/multi-middleware"
+
+# Method Exclusion Test Endpoint
+[[endpoints]]
+id = "exclude-methods-endpoint"
+listener_id = "http"
+
+# Logger that excludes HEAD and OPTIONS methods
+[[endpoints.middlewares]]
+id = "exclude-methods-logger"
+type = "console_logger"
+
+[endpoints.middlewares.console_logger]
+exclude_methods = ["HEAD", "OPTIONS"]
+output = "{{.LogFile}}.exclude-methods.log"
+preset = "standard"
+
+[endpoints.middlewares.console_logger.options]
+format = "json"
+level = "info"
+
+[[endpoints.routes]]
+app_id = "exclude-methods-echo"
+[endpoints.routes.http]
+path_prefix = "/exclude-methods"
+
+[[apps]]
+id = "multi-middleware-echo"
+[apps.echo]
+response = "Multi Middleware Response"
+
+[[apps]]
+id = "exclude-methods-echo"
+[apps.echo]
+response = "Exclude Methods Response"

--- a/internal/server/integration_tests/http/testdata/logger_integration.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/logger_integration.toml.tmpl
@@ -1,0 +1,240 @@
+# FireLynx Integration Test Configuration: Logger with File Output
+# Template variables: {{.Port}}, {{.LogFile}}
+version = "v1"
+
+# HTTP Listener Configuration
+[[listeners]]
+id = "http"
+address = "127.0.0.1:{{.Port}}"
+type = "http"
+
+[listeners.http]
+read_timeout = "30s"
+write_timeout = "30s"
+
+# Main Endpoint with Standard Logger
+[[endpoints]]
+id = "main"
+listener_id = "http"
+
+[[endpoints.middlewares]]
+id = "standard-logger"
+type = "console_logger"
+
+[endpoints.middlewares.console_logger]
+preset = "standard"                    # Use standard preset (method, path, status, client_ip, duration)
+output = "{{.LogFile}}"                # Output to file instead of stdout
+exclude_paths = ["/health"]            # Skip health checks
+
+[endpoints.middlewares.console_logger.options]
+format = "json"                        # JSON format for easy parsing
+level = "info"                         # Info level logging
+
+[[endpoints.routes]]
+app_id = "test-echo"
+[endpoints.routes.http]
+path_prefix = "/test"
+
+# Environment Variable Endpoint with Detailed Logger  
+[[endpoints]]
+id = "env-endpoint"
+listener_id = "http"
+
+[[endpoints.middlewares]]
+id = "env-logger"
+type = "console_logger"
+
+[endpoints.middlewares.console_logger]
+preset = "detailed"                    # Use detailed preset (includes headers, query params)
+output = "${FIRELYNX_LOG_DIR}/access-${HOSTNAME}.log"  # Environment variable interpolation
+exclude_paths = ["/health", "/metrics"]
+
+[endpoints.middlewares.console_logger.options]
+format = "json"
+level = "debug"
+
+[[endpoints.routes]]
+app_id = "test-echo-env"
+[endpoints.routes.http]
+path_prefix = "/env-test"
+
+# Minimal Logger Endpoint
+[[endpoints]]
+id = "minimal-endpoint"
+listener_id = "http"
+
+[[endpoints.middlewares]]
+id = "minimal-logger"
+type = "console_logger"
+
+[endpoints.middlewares.console_logger]
+preset = "minimal"                     # Use minimal preset (method, path, status only)
+output = "{{.LogFile}}.minimal"        # Template-provided log file
+
+[endpoints.middlewares.console_logger.options]
+format = "json"
+level = "info"
+
+[[endpoints.routes]]
+app_id = "test-echo-minimal"
+[endpoints.routes.http]
+path_prefix = "/minimal-test"
+
+# Manual Configuration Endpoint
+[[endpoints]]
+id = "manual-endpoint"
+listener_id = "http"
+
+[[endpoints.middlewares]]
+id = "manual-logger"
+type = "console_logger"
+
+[endpoints.middlewares.console_logger]
+output = "${FIRELYNX_LOG_DIR}/manual-${TEST_SESSION}.log"  # Another env var target
+
+[endpoints.middlewares.console_logger.options]
+format = "json"
+level = "info"
+
+[endpoints.middlewares.console_logger.fields]
+# Manual field selection without preset
+method = true
+path = true
+status_code = true
+client_ip = true
+duration = true
+query_params = true
+protocol = true
+host = true
+
+[endpoints.middlewares.console_logger.fields.request]
+enabled = true
+headers = true
+include_headers = ["User-Agent", "Content-Type", "Accept"]
+exclude_headers = ["Authorization", "Cookie"]
+
+[endpoints.middlewares.console_logger.fields.response]
+enabled = true
+headers = true
+body_size = true
+include_headers = ["Content-Type", "Cache-Control"]
+exclude_headers = ["Set-Cookie"]
+
+[[endpoints.routes]]
+app_id = "test-echo-manual"
+[endpoints.routes.http]
+path_prefix = "/manual-test"
+
+# Preset Test Endpoint (same as main but different path for testing)
+[[endpoints]]
+id = "preset-endpoint"
+listener_id = "http"
+
+[[endpoints.middlewares]]
+id = "preset-logger"
+type = "console_logger"
+
+[endpoints.middlewares.console_logger]
+preset = "standard"
+output = "{{.LogFile}}"
+exclude_paths = ["/health"]
+
+[endpoints.middlewares.console_logger.options]
+format = "json"
+level = "info"
+
+[[endpoints.routes]]
+app_id = "test-echo-preset"
+[endpoints.routes.http]
+path_prefix = "/preset-test"
+
+# Path Filtering Test Endpoints (for testing exclude_paths)
+[[endpoints]]
+id = "filtering-endpoint"
+listener_id = "http"
+
+[[endpoints.middlewares]]
+id = "filtering-logger"
+type = "console_logger"
+
+[endpoints.middlewares.console_logger]
+preset = "standard"
+output = "{{.LogFile}}"
+exclude_paths = ["/health"]
+
+[endpoints.middlewares.console_logger.options]
+format = "json"
+level = "info"
+
+[[endpoints.routes]]
+app_id = "test-echo-health"
+[endpoints.routes.http]
+path_prefix = "/health"
+
+[[endpoints.routes]]
+app_id = "test-echo-normal"
+[endpoints.routes.http]
+path_prefix = "/normal"
+
+# Environment Interpolation Test Endpoint
+[[endpoints]]
+id = "env-interpolation-endpoint"
+listener_id = "http"
+
+[[endpoints.middlewares]]
+id = "env-interpolation-logger"
+type = "console_logger"
+
+[endpoints.middlewares.console_logger]
+preset = "detailed"
+output = "${FIRELYNX_LOG_DIR}/env-test-${TEST_SESSION}.log"
+
+[endpoints.middlewares.console_logger.options]
+format = "json"
+level = "debug"
+
+[[endpoints.routes]]
+app_id = "test-echo-env-interpolation"
+[endpoints.routes.http]
+path_prefix = "/env-interpolation-test"
+
+# Application Definitions
+[[apps]]
+id = "test-echo"
+[apps.echo]
+response = "Integration Test Response"
+
+[[apps]]
+id = "test-echo-env"
+[apps.echo]
+response = "Environment Variable Test Response"
+
+[[apps]]
+id = "test-echo-minimal"
+[apps.echo]
+response = "Minimal Test Response"
+
+[[apps]]
+id = "test-echo-manual"
+[apps.echo]
+response = "Manual Test Response"
+
+[[apps]]
+id = "test-echo-preset"
+[apps.echo]
+response = "Preset Test Response"
+
+[[apps]]
+id = "test-echo-health"
+[apps.echo]
+response = "Health Check Response"
+
+[[apps]]
+id = "test-echo-normal"
+[apps.echo]
+response = "Normal Test Response"
+
+[[apps]]
+id = "test-echo-env-interpolation"
+[apps.echo]
+response = "Environment Interpolation Test Response"

--- a/internal/server/integration_tests/http/testdata/single_logger.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/single_logger.toml.tmpl
@@ -1,0 +1,48 @@
+version = "v1"
+
+[[listeners]]
+id = "http"
+address = "127.0.0.1:{{.Port}}"
+type = "http"
+
+[listeners.http]
+read_timeout = "30s"
+write_timeout = "30s"
+
+[[endpoints]]
+id = "main"
+listener_id = "http"
+
+[[endpoints.middlewares]]
+id = "file-logger"
+type = "console_logger"
+
+[endpoints.middlewares.console_logger]
+output = "{{.LogFile}}"
+
+[endpoints.middlewares.console_logger.options]
+format = "json"
+level = "info"
+
+[endpoints.middlewares.console_logger.fields]
+method = true
+path = true
+status_code = true
+
+[endpoints.middlewares.console_logger.fields.request]
+enabled = true
+
+[endpoints.middlewares.console_logger.fields.response]
+enabled = true
+
+[[endpoints.routes]]
+app_id = "test-echo"
+
+[endpoints.routes.http]
+path_prefix = "/"
+
+[[apps]]
+id = "test-echo"
+
+[apps.echo]
+response = "Single Logger Test Response"

--- a/internal/server/runnables/listeners/http/cfg/adapter.go
+++ b/internal/server/runnables/listeners/http/cfg/adapter.go
@@ -202,7 +202,8 @@ func extractEndpointRoutes(
 		logger.Debug("Found app for route",
 			"app_id", httpRoute.AppID,
 			"route_id", routeID,
-			"path_prefix", httpRoute.PathPrefix)
+			"path_prefix", httpRoute.PathPrefix,
+			"middleware_count", len(httpRoute.Middlewares))
 
 		// Create a handler function for this route
 		handlerFunc := func(w http.ResponseWriter, r *http.Request) {
@@ -235,6 +236,10 @@ func extractEndpointRoutes(
 			)
 			continue
 		}
+
+		logger.Debug("Created middleware for route",
+			"route_id", routeID,
+			"middleware_count", len(middlewares))
 
 		// Create the HTTP route with the handler and middleware
 		route, err := httpserver.NewRouteFromHandlerFunc(

--- a/internal/server/runnables/listeners/http/middleware/factory.go
+++ b/internal/server/runnables/listeners/http/middleware/factory.go
@@ -31,7 +31,10 @@ func CreateMiddlewareCollection(collection middleware.MiddlewareCollection) ([]M
 func createMiddleware(id string, cfg middleware.Middleware) (Middleware, error) {
 	switch config := cfg.Config.(type) {
 	case *configLogger.ConsoleLogger:
-		consoleLogger := logger.NewConsoleLogger(id, config)
+		consoleLogger, err := logger.NewConsoleLogger(id, config)
+		if err != nil {
+			return nil, err
+		}
 		return consoleLogger.Middleware(), nil
 	default:
 		return nil, fmt.Errorf("unsupported middleware type: %T", cfg.Config)

--- a/internal/server/runnables/listeners/http/middleware/logger/logger_test.go
+++ b/internal/server/runnables/listeners/http/middleware/logger/logger_test.go
@@ -79,7 +79,8 @@ func TestNewConsoleLogger(t *testing.T) {
 		cfg.Options.Level = logger.LevelDebug
 		cfg.Options.Format = logger.FormatTxt
 
-		consoleLogger := NewConsoleLogger("test-logger", cfg)
+		consoleLogger, err := NewConsoleLogger("test-logger", cfg)
+		require.NoError(t, err)
 		assert.Equal(t, "test-logger", consoleLogger.id)
 		assert.NotNil(t, consoleLogger)
 		assert.NotNil(t, consoleLogger.filter)
@@ -91,7 +92,8 @@ func TestNewConsoleLogger(t *testing.T) {
 		cfg.Options.Level = logger.LevelInfo
 		cfg.Options.Format = logger.FormatJSON
 
-		consoleLogger := NewConsoleLogger("test-logger-json", cfg)
+		consoleLogger, err := NewConsoleLogger("test-logger-json", cfg)
+		require.NoError(t, err)
 		assert.Equal(t, "test-logger-json", consoleLogger.id)
 		assert.NotNil(t, consoleLogger)
 		assert.NotNil(t, consoleLogger.filter)
@@ -102,7 +104,8 @@ func TestNewConsoleLogger(t *testing.T) {
 func TestConsoleLogger_Middleware(t *testing.T) {
 	t.Run("Middleware function creation", func(t *testing.T) {
 		cfg := logger.NewConsoleLogger()
-		consoleLogger := NewConsoleLogger("test-logger", cfg)
+		consoleLogger, err := NewConsoleLogger("test-logger", cfg)
+		require.NoError(t, err)
 		middleware := consoleLogger.Middleware()
 
 		assert.NotNil(t, middleware)
@@ -114,7 +117,8 @@ func TestConsoleLogger_Middleware(t *testing.T) {
 		cfg.Fields.Request.Enabled = true
 		cfg.Fields.Response.Enabled = true
 
-		consoleLogger := NewConsoleLogger("test-logger", cfg)
+		consoleLogger, err := NewConsoleLogger("test-logger", cfg)
+		require.NoError(t, err)
 		middleware := consoleLogger.Middleware()
 
 		assert.NotNil(t, middleware)

--- a/internal/server/runnables/listeners/http/middleware/logger/manual_config_test.go
+++ b/internal/server/runnables/listeners/http/middleware/logger/manual_config_test.go
@@ -1,0 +1,76 @@
+package logger
+
+import (
+	"testing"
+
+	configLogger "github.com/atlanticdynamic/firelynx/internal/config/endpoints/middleware/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManualConfigurationWithNoPreset(t *testing.T) {
+	// This test verifies that manual field configuration works when no preset is set
+	cfg := &configLogger.ConsoleLogger{
+		Options: configLogger.LogOptionsGeneral{
+			Format: configLogger.FormatJSON,
+			Level:  configLogger.LevelWarn,
+		},
+		Fields: configLogger.LogOptionsHTTP{
+			Method:      true,
+			Path:        true,
+			StatusCode:  true,
+			ClientIP:    true,
+			Duration:    true,
+			QueryParams: true,
+			Protocol:    true,
+			Host:        true,
+			Request: configLogger.DirectionConfig{
+				Enabled:        true,
+				Headers:        true,
+				IncludeHeaders: []string{"User-Agent", "Content-Type", "Accept"},
+				ExcludeHeaders: []string{"Authorization", "Cookie"},
+			},
+			Response: configLogger.DirectionConfig{
+				Enabled:        true,
+				Headers:        true,
+				BodySize:       true,
+				IncludeHeaders: []string{"Content-Type", "Cache-Control"},
+				ExcludeHeaders: []string{"Set-Cookie"},
+			},
+		},
+		Output: "/tmp/manual.log",
+		Preset: configLogger.PresetUnspecified, // No preset
+	}
+
+	// Create the middleware
+	middleware, err := NewConsoleLogger("manual-logger", cfg)
+	require.NoError(t, err, "Middleware creation should succeed")
+	require.NotNil(t, middleware, "Middleware should be created")
+
+	// Check that the original configuration still has the manual fields
+	assert.True(t, cfg.Fields.Method, "Original config should have method enabled")
+	assert.True(t, cfg.Fields.Path, "Original config should have path enabled")
+	assert.True(t, cfg.Fields.StatusCode, "Original config should have status_code enabled")
+	assert.True(t, cfg.Fields.ClientIP, "Original config should have client_ip enabled")
+	assert.True(t, cfg.Fields.Duration, "Original config should have duration enabled")
+	assert.True(t, cfg.Fields.QueryParams, "Original config should have query_params enabled")
+	assert.True(t, cfg.Fields.Protocol, "Original config should have protocol enabled")
+	assert.True(t, cfg.Fields.Host, "Original config should have host enabled")
+
+	// Check request direction config
+	assert.True(t, cfg.Fields.Request.Enabled, "Request should be enabled")
+	assert.True(t, cfg.Fields.Request.Headers, "Request headers should be enabled")
+	assert.Equal(
+		t,
+		[]string{"User-Agent", "Content-Type", "Accept"},
+		cfg.Fields.Request.IncludeHeaders,
+	)
+	assert.Equal(t, []string{"Authorization", "Cookie"}, cfg.Fields.Request.ExcludeHeaders)
+
+	// Check response direction config
+	assert.True(t, cfg.Fields.Response.Enabled, "Response should be enabled")
+	assert.True(t, cfg.Fields.Response.Headers, "Response headers should be enabled")
+	assert.True(t, cfg.Fields.Response.BodySize, "Response body_size should be enabled")
+	assert.Equal(t, []string{"Content-Type", "Cache-Control"}, cfg.Fields.Response.IncludeHeaders)
+	assert.Equal(t, []string{"Set-Cookie"}, cfg.Fields.Response.ExcludeHeaders)
+}

--- a/internal/server/runnables/listeners/http/middleware/logger/middleware.go
+++ b/internal/server/runnables/listeners/http/middleware/logger/middleware.go
@@ -61,7 +61,10 @@ func NewConsoleLogger(id string, cfg *logger.ConsoleLogger) (*ConsoleLogger, err
 	filter := newLogFilter(&configCopy)
 
 	// Expand environment variables in output
-	expandedOutput := interpolation.ExpandEnvVars(configCopy.Output)
+	expandedOutput, err := interpolation.ExpandEnvVars(configCopy.Output)
+	if err != nil {
+		return nil, fmt.Errorf("environment variable expansion failed: %w", err)
+	}
 
 	// Create writer based on output configuration
 	writer, err := writers.CreateWriter(expandedOutput)

--- a/internal/server/runnables/txmgr/orchestrator/saga_test.go
+++ b/internal/server/runnables/txmgr/orchestrator/saga_test.go
@@ -357,7 +357,7 @@ func TestGetTransactionStatus_NotFound(t *testing.T) {
 }
 
 func TestConcurrentParticipantRegistration(t *testing.T) {
-	handler := logging.SetupHandlerText("error")
+	handler := logging.SetupHandlerText("error", nil)
 	storage := txstorage.NewMemoryStorage()
 	orchestrator := NewSagaOrchestrator(storage, handler)
 
@@ -395,7 +395,7 @@ func TestConcurrentParticipantRegistration(t *testing.T) {
 // TestProcessTransactionWithNoParticipants tests that transactions
 // reach completed state even when no participants are registered for reload
 func TestProcessTransactionWithNoParticipants(t *testing.T) {
-	handler := logging.SetupHandlerText("debug")
+	handler := logging.SetupHandlerText("debug", nil)
 	storage := txstorage.NewMemoryStorage()
 	orchestrator := NewSagaOrchestrator(storage, handler)
 	ctx := t.Context()

--- a/proto/settings/v1alpha1/middleware/v1/logger.proto
+++ b/proto/settings/v1alpha1/middleware/v1/logger.proto
@@ -53,17 +53,17 @@ message LogOptionsHTTP {
   DirectionConfig response = 11; // what to log for responses
 }
 
-// Preset configurations for common logging scenarios
-enum LogPreset {
-  PRESET_UNSPECIFIED = 0;
-  PRESET_MINIMAL = 1;     // Only method, path, status code
-  PRESET_STANDARD = 2;    // Minimal + client IP, duration
-  PRESET_DETAILED = 3;    // Standard + headers, query params
-  PRESET_DEBUG = 4;       // Everything including request/response bodies
-}
-
 // Configuration for console logger middleware
 message ConsoleLoggerConfig {
+  // Preset configuration bundles for common logging scenarios
+  enum LogPreset {
+    PRESET_UNSPECIFIED = 0;
+    PRESET_MINIMAL = 1; // Only method, path, status code
+    PRESET_STANDARD = 2; // Minimal + client IP, duration
+    PRESET_DETAILED = 3; // Standard + headers, query params
+    PRESET_DEBUG = 4; // Everything including request/response bodies
+  }
+
   LogOptionsGeneral options = 1; // general logging options (format, level)
   LogOptionsHTTP fields = 2; // HTTP-specific field selection and formatting
 

--- a/proto/settings/v1alpha1/middleware/v1/logger.proto
+++ b/proto/settings/v1alpha1/middleware/v1/logger.proto
@@ -53,16 +53,32 @@ message LogOptionsHTTP {
   DirectionConfig response = 11; // what to log for responses
 }
 
+// Preset configurations for common logging scenarios
+enum LogPreset {
+  PRESET_UNSPECIFIED = 0;
+  PRESET_MINIMAL = 1;     // Only method, path, status code
+  PRESET_STANDARD = 2;    // Minimal + client IP, duration
+  PRESET_DETAILED = 3;    // Standard + headers, query params
+  PRESET_DEBUG = 4;       // Everything including request/response bodies
+}
+
 // Configuration for console logger middleware
 message ConsoleLoggerConfig {
   LogOptionsGeneral options = 1; // general logging options (format, level)
   LogOptionsHTTP fields = 2; // HTTP-specific field selection and formatting
 
+  // Output destination (supports environment variable interpolation with ${VAR_NAME})
+  // Examples: "stdout", "stderr", "/var/log/app.log", "file:///var/log/app-${HOSTNAME}.log"
+  string output = 3 [default = "stdout"];
+
+  // Preset configuration (applied before custom field overrides)
+  LogPreset preset = 4 [default = PRESET_UNSPECIFIED];
+
   // Path filtering - paths are matched as prefixes
-  repeated string include_only_paths = 3; // if set, only log requests matching these path prefixes
-  repeated string exclude_paths = 4; // exclude requests matching these path prefixes (e.g., "/health", "/metrics")
+  repeated string include_only_paths = 5; // if set, only log requests matching these path prefixes
+  repeated string exclude_paths = 6; // exclude requests matching these path prefixes (e.g., "/health", "/metrics")
 
   // Method filtering
-  repeated string include_only_methods = 5; // if set, only log these HTTP methods (e.g., ["GET", "POST"])
-  repeated string exclude_methods = 6; // exclude these HTTP methods from logging (e.g., ["OPTIONS"])
+  repeated string include_only_methods = 7; // if set, only log these HTTP methods (e.g., ["GET", "POST"])
+  repeated string exclude_methods = 8; // exclude these HTTP methods from logging (e.g., ["OPTIONS"])
 }


### PR DESCRIPTION
This change adds two new fields to the `ConsoleLogger` middleware, `Output` and `Preset`.

`Output` allows log destinations to be configured beyond the default `stdout`. It accepts file paths, "stderr", or "stdout", and supports environment variable interpolation using `${VAR_NAME}` syntax. When environment variables are referenced but not defined,
configuration validation fails.

`Preset` simplifies the logging config with predefined options: "minimal" (method, path, status), "standard" (adds client IP and duration), "detailed" (adds headers and query parameters), and "debug" (includes request/response
  bodies).

Configuration validation pre-checks output path writability before runtime.