### PR TITLE
adjust app/route instantiation

### DIFF
--- a/gen/settings/v1alpha1/static_data.pb.go
+++ b/gen/settings/v1alpha1/static_data.pb.go
@@ -23,69 +23,69 @@ const (
 )
 
 // Defines strategies for merging static data maps from different sources.
-type StaticDataMergeMode int32
+type StaticData_MergeMode int32
 
 const (
 	// Default, behavior might be defined by the consuming system (could default to FIRST or DEEP).
-	StaticDataMergeMode_STATIC_DATA_MERGE_MODE_UNSPECIFIED StaticDataMergeMode = 0
+	StaticData_MERGE_MODE_UNSPECIFIED StaticData_MergeMode = 0
 	// 'last' strategy: Uses the last value found (highest priority source wins). Later static_data completely replaces earlier ones.
-	StaticDataMergeMode_STATIC_DATA_MERGE_MODE_LAST StaticDataMergeMode = 1
+	StaticData_MERGE_MODE_LAST StaticData_MergeMode = 1
 	// 'unique' strategy: If a key exists in multiple sources, the values from the last key will replace earlier keys.
-	StaticDataMergeMode_STATIC_DATA_MERGE_MODE_UNIQUE StaticDataMergeMode = 2
+	StaticData_MERGE_MODE_UNIQUE StaticData_MergeMode = 2
 )
 
-// Enum value maps for StaticDataMergeMode.
+// Enum value maps for StaticData_MergeMode.
 var (
-	StaticDataMergeMode_name = map[int32]string{
-		0: "STATIC_DATA_MERGE_MODE_UNSPECIFIED",
-		1: "STATIC_DATA_MERGE_MODE_LAST",
-		2: "STATIC_DATA_MERGE_MODE_UNIQUE",
+	StaticData_MergeMode_name = map[int32]string{
+		0: "MERGE_MODE_UNSPECIFIED",
+		1: "MERGE_MODE_LAST",
+		2: "MERGE_MODE_UNIQUE",
 	}
-	StaticDataMergeMode_value = map[string]int32{
-		"STATIC_DATA_MERGE_MODE_UNSPECIFIED": 0,
-		"STATIC_DATA_MERGE_MODE_LAST":        1,
-		"STATIC_DATA_MERGE_MODE_UNIQUE":      2,
+	StaticData_MergeMode_value = map[string]int32{
+		"MERGE_MODE_UNSPECIFIED": 0,
+		"MERGE_MODE_LAST":        1,
+		"MERGE_MODE_UNIQUE":      2,
 	}
 )
 
-func (x StaticDataMergeMode) Enum() *StaticDataMergeMode {
-	p := new(StaticDataMergeMode)
+func (x StaticData_MergeMode) Enum() *StaticData_MergeMode {
+	p := new(StaticData_MergeMode)
 	*p = x
 	return p
 }
 
-func (x StaticDataMergeMode) String() string {
+func (x StaticData_MergeMode) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (StaticDataMergeMode) Descriptor() protoreflect.EnumDescriptor {
+func (StaticData_MergeMode) Descriptor() protoreflect.EnumDescriptor {
 	return file_settings_v1alpha1_static_data_proto_enumTypes[0].Descriptor()
 }
 
-func (StaticDataMergeMode) Type() protoreflect.EnumType {
+func (StaticData_MergeMode) Type() protoreflect.EnumType {
 	return &file_settings_v1alpha1_static_data_proto_enumTypes[0]
 }
 
-func (x StaticDataMergeMode) Number() protoreflect.EnumNumber {
+func (x StaticData_MergeMode) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use StaticDataMergeMode.Descriptor instead.
-func (StaticDataMergeMode) EnumDescriptor() ([]byte, []int) {
-	return file_settings_v1alpha1_static_data_proto_rawDescGZIP(), []int{0}
+// Deprecated: Use StaticData_MergeMode.Descriptor instead.
+func (StaticData_MergeMode) EnumDescriptor() ([]byte, []int) {
+	return file_settings_v1alpha1_static_data_proto_rawDescGZIP(), []int{0, 0}
 }
 
 type StaticData struct {
 	state         protoimpl.MessageState     `protogen:"open.v1"`
 	Data          map[string]*structpb.Value `protobuf:"bytes,1,rep,name=data" json:"data,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	MergeMode     *StaticDataMergeMode       `protobuf:"varint,2,opt,name=merge_mode,json=mergeMode,enum=settings.v1alpha1.StaticDataMergeMode,def=0" json:"merge_mode,omitempty"`
+	MergeMode     *StaticData_MergeMode      `protobuf:"varint,2,opt,name=merge_mode,json=mergeMode,enum=settings.v1alpha1.StaticData_MergeMode,def=0" json:"merge_mode,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 // Default values for StaticData fields.
 const (
-	Default_StaticData_MergeMode = StaticDataMergeMode_STATIC_DATA_MERGE_MODE_UNSPECIFIED
+	Default_StaticData_MergeMode = StaticData_MERGE_MODE_UNSPECIFIED
 )
 
 func (x *StaticData) Reset() {
@@ -125,7 +125,7 @@ func (x *StaticData) GetData() map[string]*structpb.Value {
 	return nil
 }
 
-func (x *StaticData) GetMergeMode() StaticDataMergeMode {
+func (x *StaticData) GetMergeMode() StaticData_MergeMode {
 	if x != nil && x.MergeMode != nil {
 		return *x.MergeMode
 	}
@@ -136,19 +136,19 @@ var File_settings_v1alpha1_static_data_proto protoreflect.FileDescriptor
 
 const file_settings_v1alpha1_static_data_proto_rawDesc = "" +
 	"\n" +
-	"#settings/v1alpha1/static_data.proto\x12\x11settings.v1alpha1\x1a\x1cgoogle/protobuf/struct.proto\"\x85\x02\n" +
+	"#settings/v1alpha1/static_data.proto\x12\x11settings.v1alpha1\x1a\x1cgoogle/protobuf/struct.proto\"\xcf\x02\n" +
 	"\n" +
 	"StaticData\x12;\n" +
-	"\x04data\x18\x01 \x03(\v2'.settings.v1alpha1.StaticData.DataEntryR\x04data\x12i\n" +
+	"\x04data\x18\x01 \x03(\v2'.settings.v1alpha1.StaticData.DataEntryR\x04data\x12^\n" +
 	"\n" +
-	"merge_mode\x18\x02 \x01(\x0e2&.settings.v1alpha1.StaticDataMergeMode:\"STATIC_DATA_MERGE_MODE_UNSPECIFIEDR\tmergeMode\x1aO\n" +
+	"merge_mode\x18\x02 \x01(\x0e2'.settings.v1alpha1.StaticData.MergeMode:\x16MERGE_MODE_UNSPECIFIEDR\tmergeMode\x1aO\n" +
 	"\tDataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12,\n" +
-	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01*\x81\x01\n" +
-	"\x13StaticDataMergeMode\x12&\n" +
-	"\"STATIC_DATA_MERGE_MODE_UNSPECIFIED\x10\x00\x12\x1f\n" +
-	"\x1bSTATIC_DATA_MERGE_MODE_LAST\x10\x01\x12!\n" +
-	"\x1dSTATIC_DATA_MERGE_MODE_UNIQUE\x10\x02B;Z9github.com/atlanticdynamic/firelynx/gen/settings/v1alpha1b\beditionsp\xe8\a"
+	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01\"S\n" +
+	"\tMergeMode\x12\x1a\n" +
+	"\x16MERGE_MODE_UNSPECIFIED\x10\x00\x12\x13\n" +
+	"\x0fMERGE_MODE_LAST\x10\x01\x12\x15\n" +
+	"\x11MERGE_MODE_UNIQUE\x10\x02B;Z9github.com/atlanticdynamic/firelynx/gen/settings/v1alpha1b\beditionsp\xe8\a"
 
 var (
 	file_settings_v1alpha1_static_data_proto_rawDescOnce sync.Once
@@ -165,14 +165,14 @@ func file_settings_v1alpha1_static_data_proto_rawDescGZIP() []byte {
 var file_settings_v1alpha1_static_data_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_settings_v1alpha1_static_data_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_settings_v1alpha1_static_data_proto_goTypes = []any{
-	(StaticDataMergeMode)(0), // 0: settings.v1alpha1.StaticDataMergeMode
-	(*StaticData)(nil),       // 1: settings.v1alpha1.StaticData
-	nil,                      // 2: settings.v1alpha1.StaticData.DataEntry
-	(*structpb.Value)(nil),   // 3: google.protobuf.Value
+	(StaticData_MergeMode)(0), // 0: settings.v1alpha1.StaticData.MergeMode
+	(*StaticData)(nil),        // 1: settings.v1alpha1.StaticData
+	nil,                       // 2: settings.v1alpha1.StaticData.DataEntry
+	(*structpb.Value)(nil),    // 3: google.protobuf.Value
 }
 var file_settings_v1alpha1_static_data_proto_depIdxs = []int32{
 	2, // 0: settings.v1alpha1.StaticData.data:type_name -> settings.v1alpha1.StaticData.DataEntry
-	0, // 1: settings.v1alpha1.StaticData.merge_mode:type_name -> settings.v1alpha1.StaticDataMergeMode
+	0, // 1: settings.v1alpha1.StaticData.merge_mode:type_name -> settings.v1alpha1.StaticData.MergeMode
 	3, // 2: settings.v1alpha1.StaticData.DataEntry.value:type_name -> google.protobuf.Value
 	3, // [3:3] is the sub-list for method output_type
 	3, // [3:3] is the sub-list for method input_type

--- a/internal/config/apps/apps_test.go
+++ b/internal/config/apps/apps_test.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	validRisorCode42 = "func handler() { return 42 }\nhandler()"
+	validRisorCode43 = "func handler() { return 43 }\nhandler()"
+)
+
 func TestAppValidate(t *testing.T) {
 	t.Parallel()
 
@@ -25,7 +30,7 @@ func TestAppValidate(t *testing.T) {
 				ID: "valid-app",
 				Config: scripts.NewAppScript(
 					&staticdata.StaticData{Data: map[string]any{"key": "value"}},
-					&evaluators.RisorEvaluator{Code: "return 42"},
+					&evaluators.RisorEvaluator{Code: validRisorCode42},
 				),
 			},
 			expectError: false,
@@ -36,7 +41,7 @@ func TestAppValidate(t *testing.T) {
 				ID: "",
 				Config: scripts.NewAppScript(
 					&staticdata.StaticData{Data: map[string]any{"key": "value"}},
-					&evaluators.RisorEvaluator{Code: "return 42"},
+					&evaluators.RisorEvaluator{Code: validRisorCode42},
 				),
 			},
 			expectError: true,
@@ -85,14 +90,14 @@ func TestAppCollectionValidate(t *testing.T) {
 					ID: "app1",
 					Config: scripts.NewAppScript(
 						&staticdata.StaticData{Data: map[string]any{"key": "value"}},
-						&evaluators.RisorEvaluator{Code: "return 42"},
+						&evaluators.RisorEvaluator{Code: validRisorCode42},
 					),
 				},
 				{
 					ID: "app2",
 					Config: scripts.NewAppScript(
 						&staticdata.StaticData{Data: map[string]any{"key": "value2"}},
-						&evaluators.RisorEvaluator{Code: "return 43"},
+						&evaluators.RisorEvaluator{Code: validRisorCode43},
 					),
 				},
 			},
@@ -105,14 +110,14 @@ func TestAppCollectionValidate(t *testing.T) {
 					ID: "app1",
 					Config: scripts.NewAppScript(
 						&staticdata.StaticData{Data: map[string]any{"key": "value"}},
-						&evaluators.RisorEvaluator{Code: "return 42"},
+						&evaluators.RisorEvaluator{Code: validRisorCode42},
 					),
 				},
 				{
 					ID: "app1",
 					Config: scripts.NewAppScript(
 						&staticdata.StaticData{Data: map[string]any{"key": "value2"}},
-						&evaluators.RisorEvaluator{Code: "return 43"},
+						&evaluators.RisorEvaluator{Code: validRisorCode43},
 					),
 				},
 			},
@@ -125,7 +130,7 @@ func TestAppCollectionValidate(t *testing.T) {
 					ID: "script1",
 					Config: scripts.NewAppScript(
 						&staticdata.StaticData{Data: map[string]any{"key": "value"}},
-						&evaluators.RisorEvaluator{Code: "return 42"},
+						&evaluators.RisorEvaluator{Code: validRisorCode42},
 					),
 				},
 				{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,6 +111,8 @@ func NewFromProto(pbConfig *pb.ServerConfig) (*Config, error) {
 			appErrz = append(appErrz, fmt.Errorf("failed to convert apps: %w", err))
 		} else {
 			config.Apps = appDefinitions
+			// Assign app instances to routes with merged static data
+			expandAppsForRoutes(config.Apps, config.Endpoints)
 		}
 	}
 

--- a/internal/config/endpoints/routes/routes.go
+++ b/internal/config/endpoints/routes/routes.go
@@ -43,6 +43,7 @@ package routes
 import (
 	"fmt"
 
+	"github.com/atlanticdynamic/firelynx/internal/config/apps"
 	"github.com/atlanticdynamic/firelynx/internal/config/endpoints/middleware"
 	"github.com/atlanticdynamic/firelynx/internal/config/endpoints/routes/conditions"
 	"github.com/atlanticdynamic/firelynx/internal/fancy"
@@ -57,6 +58,7 @@ type RouteCollection []Route
 // Route represents a rule for directing traffic to an application
 type Route struct {
 	AppID       string
+	App         *apps.App
 	StaticData  map[string]any
 	Condition   conditions.Condition
 	Middlewares middleware.MiddlewareCollection
@@ -100,6 +102,7 @@ func (r RouteCollection) GetStructuredHTTPRoutes() []HTTPRoute {
 			PathPrefix: httpCond.PathPrefix,
 			Method:     httpCond.Method,
 			AppID:      route.AppID,
+			App:        route.App,
 			StaticData: route.StaticData,
 		}
 

--- a/internal/config/endpoints/routes/types.go
+++ b/internal/config/endpoints/routes/types.go
@@ -1,12 +1,16 @@
 package routes
 
-import "github.com/atlanticdynamic/firelynx/internal/config/endpoints/middleware"
+import (
+	"github.com/atlanticdynamic/firelynx/internal/config/apps"
+	"github.com/atlanticdynamic/firelynx/internal/config/endpoints/middleware"
+)
 
 // HTTPRoute represents an HTTP-specific route derived from a domain route
 type HTTPRoute struct {
 	PathPrefix  string
 	Method      string
 	AppID       string
+	App         *apps.App
 	StaticData  map[string]any
 	Middlewares middleware.MiddlewareCollection
 }

--- a/internal/config/errz/errors.go
+++ b/internal/config/errz/errors.go
@@ -74,4 +74,7 @@ var (
 
 	// ErrInvalidEndpointFormat is returned when an endpoint has invalid format
 	ErrInvalidEndpointFormat = errors.New("invalid endpoint format")
+
+	// ErrInvalidAppFormat is returned when an app has invalid format
+	ErrInvalidAppFormat = errors.New("invalid app format")
 )

--- a/internal/config/expand_apps.go
+++ b/internal/config/expand_apps.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"fmt"
+	"maps"
+
+	"github.com/atlanticdynamic/firelynx/internal/config/apps"
+	"github.com/atlanticdynamic/firelynx/internal/config/apps/scripts"
+	"github.com/atlanticdynamic/firelynx/internal/config/endpoints"
+	"github.com/atlanticdynamic/firelynx/internal/config/staticdata"
+)
+
+// expandAppsForRoutes assigns app instances to routes with merged static data.
+// Each route gets its own app instance with route-specific static data merged in.
+// Expanded apps get unique IDs to avoid conflicts in the server registry.
+func expandAppsForRoutes(appCollection apps.AppCollection, endpoints endpoints.EndpointCollection) {
+	if len(appCollection) == 0 || len(endpoints) == 0 {
+		return
+	}
+
+	// Create a map for fast app lookup by ID
+	appMap := make(map[string]apps.App)
+	for _, app := range appCollection {
+		appMap[app.ID] = app
+	}
+
+	// Process each endpoint
+	for endpointIndex := range endpoints {
+		endpoint := &endpoints[endpointIndex]
+
+		// Process each route in the endpoint
+		for routeIndex := range endpoint.Routes {
+			route := &endpoint.Routes[routeIndex]
+
+			if route.AppID == "" {
+				continue
+			}
+
+			// Find the original app
+			originalApp, exists := appMap[route.AppID]
+			if !exists {
+				continue // Skip invalid app references, validation will catch this
+			}
+
+			// Create unique app ID for this route's app instance
+			expandedAppID := fmt.Sprintf("%s#%d:%d", route.AppID, endpointIndex, routeIndex)
+
+			// Clone the app and merge route-specific static data
+			routeApp := cloneAppWithMergedStaticData(originalApp, route.StaticData, expandedAppID)
+			route.App = &routeApp
+
+			// Keep route.AppID as original for validation, but store expanded app separately
+		}
+	}
+}
+
+// cloneAppWithMergedStaticData creates a copy of an app with route static data merged in
+func cloneAppWithMergedStaticData(
+	originalApp apps.App,
+	routeStaticData map[string]any,
+	newAppID string,
+) apps.App {
+	// Create a new app with the unique expanded ID
+	clonedApp := apps.App{
+		ID: newAppID,
+	}
+
+	// Clone the config based on app type
+	switch config := originalApp.Config.(type) {
+	case *scripts.AppScript:
+		clonedConfig := &scripts.AppScript{
+			Evaluator: config.Evaluator, // Evaluator can be shared (immutable)
+		}
+
+		// Merge static data
+		clonedConfig.StaticData = mergeStaticDataForApp(config.StaticData, routeStaticData)
+		clonedApp.Config = clonedConfig
+
+	default:
+		// For other app types (echo, composite), just copy the config
+		// They don't support static data merging yet
+		clonedApp.Config = originalApp.Config
+	}
+
+	return clonedApp
+}
+
+// mergeStaticDataForApp merges route-level static data into app-level static data
+func mergeStaticDataForApp(
+	appStaticData *staticdata.StaticData,
+	routeStaticData map[string]any,
+) *staticdata.StaticData {
+	if len(routeStaticData) == 0 {
+		return appStaticData
+	}
+
+	// Start with app-level data (if any)
+	mergedData := make(map[string]any)
+	if appStaticData != nil && appStaticData.Data != nil {
+		maps.Copy(mergedData, appStaticData.Data)
+	}
+
+	// Route data overwrites app data for the same keys
+	maps.Copy(mergedData, routeStaticData)
+
+	// Determine merge mode
+	mergeMode := staticdata.StaticDataMergeModeUnique // Default
+	if appStaticData != nil {
+		mergeMode = appStaticData.MergeMode
+	}
+
+	return &staticdata.StaticData{
+		Data:      mergedData,
+		MergeMode: mergeMode,
+	}
+}

--- a/internal/config/loader/toml/toml_duration_test.go
+++ b/internal/config/loader/toml/toml_duration_test.go
@@ -1,0 +1,103 @@
+package toml
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDurationConversion tests different duration formats in TOML config
+func TestDurationConversion(t *testing.T) {
+	tests := []struct {
+		name          string
+		tomlContent   string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "Standard duration format 1s",
+			tomlContent: `
+version = "v1"
+
+[[apps]]
+id = "test-script"
+[apps.script]
+[apps.script.risor]
+code = "print('hello')"
+timeout = "1s"
+`,
+			expectError: false,
+		},
+		{
+			name: "Millisecond format 1000ms",
+			tomlContent: `
+version = "v1"
+
+[[apps]]
+id = "test-script"
+[apps.script]
+[apps.script.risor]
+code = "print('hello')"
+timeout = "1000ms"
+`,
+			expectError: false,
+		},
+		{
+			name: "Decimal second format 0.001s",
+			tomlContent: `
+version = "v1"
+
+[[apps]]
+id = "test-script"
+[apps.script]
+[apps.script.risor]
+code = "print('hello')"
+timeout = "0.001s"
+`,
+			expectError: false,
+		},
+		{
+			name: "Very short millisecond format 1ms",
+			tomlContent: `
+version = "v1"
+
+[[apps]]
+id = "test-script"
+[apps.script]
+[apps.script.risor]
+code = "print('hello')"
+timeout = "1ms"
+`,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loader := NewTomlLoader([]byte(tt.tomlContent))
+			config, err := loader.LoadProto()
+
+			if tt.expectError {
+				require.Error(t, err, "Expected error but got none")
+				if tt.errorContains != "" {
+					assert.Contains(
+						t,
+						err.Error(),
+						tt.errorContains,
+						"Error should contain expected text",
+					)
+				}
+				assert.Nil(t, config, "Config should be nil on error")
+			} else {
+				require.NoError(t, err, "Expected no error but got: %v", err)
+				require.NotNil(t, config, "Config should not be nil")
+
+				// Verify the config was loaded correctly
+				assert.Equal(t, "v1", config.GetVersion())
+				assert.Len(t, config.GetApps(), 1)
+				assert.Equal(t, "test-script", config.GetApps()[0].GetId())
+			}
+		})
+	}
+}

--- a/internal/config/proto.go
+++ b/internal/config/proto.go
@@ -62,6 +62,8 @@ func fromProto(pbConfig *pb.ServerConfig) (*Config, error) {
 			return nil, fmt.Errorf("%w: %w", ErrFailedToConvertConfig, err)
 		}
 		config.Apps = appDefinitions
+		// Assign app instances to routes with merged static data
+		expandAppsForRoutes(config.Apps, config.Endpoints)
 	}
 
 	return config, nil

--- a/internal/config/staticdata/proto.go
+++ b/internal/config/staticdata/proto.go
@@ -42,29 +42,29 @@ func FromProto(proto *settingsv1alpha1.StaticData) (*StaticData, error) {
 }
 
 // staticDataMergeModeToProto converts a StaticDataMergeMode to its protocol buffer representation.
-func staticDataMergeModeToProto(mode StaticDataMergeMode) *settingsv1alpha1.StaticDataMergeMode {
-	var protoMode settingsv1alpha1.StaticDataMergeMode
+func staticDataMergeModeToProto(mode StaticDataMergeMode) *settingsv1alpha1.StaticData_MergeMode {
+	var protoMode settingsv1alpha1.StaticData_MergeMode
 	switch mode {
 	case StaticDataMergeModeUnspecified:
-		protoMode = settingsv1alpha1.StaticDataMergeMode_STATIC_DATA_MERGE_MODE_UNSPECIFIED
+		protoMode = settingsv1alpha1.StaticData_MERGE_MODE_UNSPECIFIED
 	case StaticDataMergeModeLast:
-		protoMode = settingsv1alpha1.StaticDataMergeMode_STATIC_DATA_MERGE_MODE_LAST
+		protoMode = settingsv1alpha1.StaticData_MERGE_MODE_LAST
 	case StaticDataMergeModeUnique:
-		protoMode = settingsv1alpha1.StaticDataMergeMode_STATIC_DATA_MERGE_MODE_UNIQUE
+		protoMode = settingsv1alpha1.StaticData_MERGE_MODE_UNIQUE
 	default:
-		protoMode = settingsv1alpha1.StaticDataMergeMode_STATIC_DATA_MERGE_MODE_UNSPECIFIED
+		protoMode = settingsv1alpha1.StaticData_MERGE_MODE_UNSPECIFIED
 	}
 	return &protoMode
 }
 
 // protoToStaticDataMergeMode converts a protocol buffer StaticDataMergeMode to its domain model representation.
-func protoToStaticDataMergeMode(mode settingsv1alpha1.StaticDataMergeMode) StaticDataMergeMode {
+func protoToStaticDataMergeMode(mode settingsv1alpha1.StaticData_MergeMode) StaticDataMergeMode {
 	switch mode {
-	case settingsv1alpha1.StaticDataMergeMode_STATIC_DATA_MERGE_MODE_UNSPECIFIED:
+	case settingsv1alpha1.StaticData_MERGE_MODE_UNSPECIFIED:
 		return StaticDataMergeModeUnspecified
-	case settingsv1alpha1.StaticDataMergeMode_STATIC_DATA_MERGE_MODE_LAST:
+	case settingsv1alpha1.StaticData_MERGE_MODE_LAST:
 		return StaticDataMergeModeLast
-	case settingsv1alpha1.StaticDataMergeMode_STATIC_DATA_MERGE_MODE_UNIQUE:
+	case settingsv1alpha1.StaticData_MERGE_MODE_UNIQUE:
 		return StaticDataMergeModeUnique
 	default:
 		return StaticDataMergeModeUnspecified

--- a/internal/config/staticdata/proto_test.go
+++ b/internal/config/staticdata/proto_test.go
@@ -25,7 +25,7 @@ func TestStaticDataToProto(t *testing.T) {
 		require.NotNil(t, pb.MergeMode)
 		assert.Equal(
 			t,
-			settingsv1alpha1.StaticDataMergeMode_STATIC_DATA_MERGE_MODE_UNSPECIFIED,
+			settingsv1alpha1.StaticData_MERGE_MODE_UNSPECIFIED,
 			*pb.MergeMode,
 		)
 		assert.Nil(t, pb.Data)
@@ -44,7 +44,7 @@ func TestStaticDataToProto(t *testing.T) {
 		require.NotNil(t, pb.MergeMode)
 		assert.Equal(
 			t,
-			settingsv1alpha1.StaticDataMergeMode_STATIC_DATA_MERGE_MODE_LAST,
+			settingsv1alpha1.StaticData_MERGE_MODE_LAST,
 			*pb.MergeMode,
 		)
 		assert.Len(t, pb.Data, 3)
@@ -65,7 +65,7 @@ func TestFromProto(t *testing.T) {
 	})
 
 	t.Run("EmptyProto", func(t *testing.T) {
-		mergeMode := settingsv1alpha1.StaticDataMergeMode_STATIC_DATA_MERGE_MODE_UNSPECIFIED
+		mergeMode := settingsv1alpha1.StaticData_MERGE_MODE_UNSPECIFIED
 		pb := &settingsv1alpha1.StaticData{
 			MergeMode: &mergeMode,
 		}
@@ -77,7 +77,7 @@ func TestFromProto(t *testing.T) {
 
 	t.Run("FullProto", func(t *testing.T) {
 		// Create a proto StaticData with some values
-		mergeMode := settingsv1alpha1.StaticDataMergeMode_STATIC_DATA_MERGE_MODE_UNIQUE
+		mergeMode := settingsv1alpha1.StaticData_MERGE_MODE_UNIQUE
 		pb := &settingsv1alpha1.StaticData{
 			Data:      map[string]*structpb.Value{},
 			MergeMode: &mergeMode,
@@ -104,23 +104,23 @@ func TestStaticDataMergeModeConversion(t *testing.T) {
 	t.Run("DomainToProto", func(t *testing.T) {
 		tests := []struct {
 			domain   StaticDataMergeMode
-			expected settingsv1alpha1.StaticDataMergeMode
+			expected settingsv1alpha1.StaticData_MergeMode
 		}{
 			{
 				StaticDataMergeModeUnspecified,
-				settingsv1alpha1.StaticDataMergeMode_STATIC_DATA_MERGE_MODE_UNSPECIFIED,
+				settingsv1alpha1.StaticData_MERGE_MODE_UNSPECIFIED,
 			},
 			{
 				StaticDataMergeModeLast,
-				settingsv1alpha1.StaticDataMergeMode_STATIC_DATA_MERGE_MODE_LAST,
+				settingsv1alpha1.StaticData_MERGE_MODE_LAST,
 			},
 			{
 				StaticDataMergeModeUnique,
-				settingsv1alpha1.StaticDataMergeMode_STATIC_DATA_MERGE_MODE_UNIQUE,
+				settingsv1alpha1.StaticData_MERGE_MODE_UNIQUE,
 			},
 			{
 				StaticDataMergeMode(999),
-				settingsv1alpha1.StaticDataMergeMode_STATIC_DATA_MERGE_MODE_UNSPECIFIED,
+				settingsv1alpha1.StaticData_MERGE_MODE_UNSPECIFIED,
 			}, // Invalid defaults to unspecified
 		}
 
@@ -134,23 +134,23 @@ func TestStaticDataMergeModeConversion(t *testing.T) {
 	// Test conversion from proto to domain
 	t.Run("ProtoToDomain", func(t *testing.T) {
 		tests := []struct {
-			proto    settingsv1alpha1.StaticDataMergeMode
+			proto    settingsv1alpha1.StaticData_MergeMode
 			expected StaticDataMergeMode
 		}{
 			{
-				settingsv1alpha1.StaticDataMergeMode_STATIC_DATA_MERGE_MODE_UNSPECIFIED,
+				settingsv1alpha1.StaticData_MERGE_MODE_UNSPECIFIED,
 				StaticDataMergeModeUnspecified,
 			},
 			{
-				settingsv1alpha1.StaticDataMergeMode_STATIC_DATA_MERGE_MODE_LAST,
+				settingsv1alpha1.StaticData_MERGE_MODE_LAST,
 				StaticDataMergeModeLast,
 			},
 			{
-				settingsv1alpha1.StaticDataMergeMode_STATIC_DATA_MERGE_MODE_UNIQUE,
+				settingsv1alpha1.StaticData_MERGE_MODE_UNIQUE,
 				StaticDataMergeModeUnique,
 			},
 			{
-				settingsv1alpha1.StaticDataMergeMode(999),
+				settingsv1alpha1.StaticData_MergeMode(999),
 				StaticDataMergeModeUnspecified,
 			}, // Invalid defaults to unspecified
 		}

--- a/internal/config/transaction/transaction_test.go
+++ b/internal/config/transaction/transaction_test.go
@@ -550,10 +550,22 @@ func TestConvertToAppDefinitions(t *testing.T) {
 
 			require.Len(t, result, len(tt.expected))
 
-			for i, def := range result {
-				assert.Equal(t, tt.expected[i].ID, def.ID)
-				assert.Equal(t, tt.expected[i].Config, def.Config)
+			// Create a map of expected apps for order-independent comparison
+			expectedMap := make(map[string]serverApps.AppDefinition)
+			for _, exp := range tt.expected {
+				expectedMap[exp.ID] = exp
 			}
+
+			// Check that all results are in the expected set
+			for _, def := range result {
+				expected, ok := expectedMap[def.ID]
+				require.True(t, ok, "unexpected app ID: %s", def.ID)
+				assert.Equal(t, expected.Config, def.Config)
+				delete(expectedMap, def.ID)
+			}
+
+			// Ensure all expected apps were found
+			assert.Empty(t, expectedMap, "missing expected apps: %v", expectedMap)
 		})
 	}
 }

--- a/proto/settings/v1alpha1/static_data.proto
+++ b/proto/settings/v1alpha1/static_data.proto
@@ -7,18 +7,18 @@ import "google/protobuf/struct.proto";
 option go_package = "github.com/atlanticdynamic/firelynx/gen/settings/v1alpha1";
 
 message StaticData {
+  // Defines strategies for merging static data maps from different sources.
+  enum MergeMode {
+    // Default, behavior might be defined by the consuming system (could default to FIRST or DEEP).
+    MERGE_MODE_UNSPECIFIED = 0;
+
+    // 'last' strategy: Uses the last value found (highest priority source wins). Later static_data completely replaces earlier ones.
+    MERGE_MODE_LAST = 1;
+
+    // 'unique' strategy: If a key exists in multiple sources, the values from the last key will replace earlier keys.
+    MERGE_MODE_UNIQUE = 2;
+  }
+
   map<string, google.protobuf.Value> data = 1;
-  StaticDataMergeMode merge_mode = 2 [default = STATIC_DATA_MERGE_MODE_UNSPECIFIED];
-}
-
-// Defines strategies for merging static data maps from different sources.
-enum StaticDataMergeMode {
-  // Default, behavior might be defined by the consuming system (could default to FIRST or DEEP).
-  STATIC_DATA_MERGE_MODE_UNSPECIFIED = 0;
-
-  // 'last' strategy: Uses the last value found (highest priority source wins). Later static_data completely replaces earlier ones.
-  STATIC_DATA_MERGE_MODE_LAST = 1;
-
-  // 'unique' strategy: If a key exists in multiple sources, the values from the last key will replace earlier keys.
-  STATIC_DATA_MERGE_MODE_UNIQUE = 2;
+  MergeMode merge_mode = 2 [default = MERGE_MODE_UNSPECIFIED];
 }


### PR DESCRIPTION
Extract app/route instantiation foundation from the polyscript feature branch #60 . This change separates the core infrastructure for route-app binding from script runtime functionality, enabling routes app instances with layered static-data.

The existing implementation has routes that reference apps by string ID only. This change allows routes to reference actual app instances with merged static data, which is needed for #60 where the static-data can be defined and merged in multiple places.