### PR TITLE
fix a bug with default values ignored in http listener

### DIFF
--- a/cmd/firelynx/client/testdata/test_config.toml
+++ b/cmd/firelynx/client/testdata/test_config.toml
@@ -5,10 +5,6 @@ id = "test_listener"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-idle_timeout = "120s"
 
 [[endpoints]]
 id = "test_endpoint"

--- a/cmd/firelynx/client/testdata/updated_config.toml
+++ b/cmd/firelynx/client/testdata/updated_config.toml
@@ -5,10 +5,6 @@ id = "test_listener"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-idle_timeout = "120s"
 
 [[endpoints]]
 id = "test_endpoint"

--- a/cmd/firelynx/server/testdata/basic_config.toml
+++ b/cmd/firelynx/server/testdata/basic_config.toml
@@ -9,10 +9,6 @@ id = "test_listener"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-idle_timeout = "120s"
 
 [[endpoints]]
 id = "test_endpoint"

--- a/cmd/firelynx/server/testdata/grpc_config.toml
+++ b/cmd/firelynx/server/testdata/grpc_config.toml
@@ -9,10 +9,6 @@ id = "grpc_test_listener"
 address = ":8081"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-idle_timeout = "120s"
 
 [[endpoints]]
 id = "grpc_test_endpoint"

--- a/cmd/firelynx/server/testdata/initial_config.toml
+++ b/cmd/firelynx/server/testdata/initial_config.toml
@@ -9,10 +9,6 @@ id = "initial_listener"
 address = ":8082"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-idle_timeout = "120s"
 
 [[endpoints]]
 id = "initial_endpoint"

--- a/cmd/firelynx/server/testdata/invalid_config.toml
+++ b/cmd/firelynx/server/testdata/invalid_config.toml
@@ -9,10 +9,6 @@ id = "test_listener"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-idle_timeout = "120s"
 
 [[endpoints]]
 id = "duplicate_endpoint"

--- a/examples/config/headers.toml
+++ b/examples/config/headers.toml
@@ -8,10 +8,6 @@ id = "http"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[endpoints]]
 id = "main"
 listener_id = "http"

--- a/examples/config/logging-full.toml
+++ b/examples/config/logging-full.toml
@@ -23,9 +23,6 @@ id = "http"
 address = ":8080"         # Listen on all interfaces, port 8080
 type = "http"             # HTTP protocol listener
 
-[listeners.http]
-read_timeout = "30s"      # Maximum time to read the entire request
-write_timeout = "30s"     # Maximum time to write the response
 
 # Endpoint Configuration
 # Connects the HTTP listener to routes and middleware

--- a/examples/config/logging-minimal.toml
+++ b/examples/config/logging-minimal.toml
@@ -14,10 +14,6 @@ id = "http"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 # Endpoint Configuration with Minimal Logger
 [[endpoints]]
 id = "main"

--- a/examples/config/logging-presets.toml
+++ b/examples/config/logging-presets.toml
@@ -22,9 +22,6 @@ id = "http"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 # Endpoint Configuration with Multiple Loggers
 [[endpoints]]

--- a/examples/config/logging.toml
+++ b/examples/config/logging.toml
@@ -14,9 +14,6 @@ id = "http"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 # Endpoint Configuration
 [[endpoints]]

--- a/examples/config/minimal_config.toml
+++ b/examples/config/minimal_config.toml
@@ -5,10 +5,6 @@ id = "http"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[endpoints]]
 id = "main"
 listener_id = "http"

--- a/examples/config/script-extism-basic.toml
+++ b/examples/config/script-extism-basic.toml
@@ -20,9 +20,6 @@ id = "http"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 # Endpoint Configuration
 [[endpoints]]

--- a/examples/config/script-risor-basic.toml
+++ b/examples/config/script-risor-basic.toml
@@ -12,9 +12,6 @@ id = "http"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 # Endpoint Configuration
 [[endpoints]]

--- a/examples/config/script-starlark-basic.toml
+++ b/examples/config/script-starlark-basic.toml
@@ -12,9 +12,6 @@ id = "http"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 # Endpoint Configuration
 [[endpoints]]

--- a/examples/config/script-with-data.toml
+++ b/examples/config/script-with-data.toml
@@ -13,9 +13,6 @@ id = "http"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 # Endpoint Configuration
 [[endpoints]]

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -502,8 +502,14 @@ func (m *mockApplyConfigFromTransactionClient) ApplyConfigFromTransaction(
 	}
 
 	// Convert protobuf to domain config for validation
-	_, err = config.NewFromProto(pbConfig)
+	domainConfig, err := config.NewFromProto(pbConfig)
 	if err != nil {
+		return fmt.Errorf("failed to convert protobuf to domain config: %w", err)
+	}
+
+	// Call Validate() explicitly since the client doesn't use the transaction layer
+	// This allows the test to verify that invalid configs are caught during validation
+	if err := domainConfig.Validate(); err != nil {
 		return fmt.Errorf("failed to convert protobuf to domain config: %w", err)
 	}
 

--- a/internal/client/testdata/test_config.toml
+++ b/internal/client/testdata/test_config.toml
@@ -9,10 +9,6 @@ id = "test_listener"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-idle_timeout = "120s"
 
 [[endpoints]]
 id = "test_endpoint"

--- a/internal/client/testdata/updated_config.toml
+++ b/internal/client/testdata/updated_config.toml
@@ -9,10 +9,6 @@ id = "test_listener"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-idle_timeout = "120s"
 
 [[endpoints]]
 id = "test_endpoint"

--- a/internal/config/apps/scripts/integration_test/testdata/extism_file_invalid.toml.tmpl
+++ b/internal/config/apps/scripts/integration_test/testdata/extism_file_invalid.toml.tmpl
@@ -5,10 +5,6 @@ id = "http"
 address = "127.0.0.1:{{.Port}}"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[endpoints]]
 id = "main"
 listener_id = "http"

--- a/internal/config/apps/scripts/integration_test/testdata/extism_file_valid.toml.tmpl
+++ b/internal/config/apps/scripts/integration_test/testdata/extism_file_valid.toml.tmpl
@@ -5,10 +5,6 @@ id = "http"
 address = "127.0.0.1:{{.Port}}"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[endpoints]]
 id = "main"
 listener_id = "http"

--- a/internal/config/apps/scripts/integration_test/testdata/extism_inline_invalid.toml.tmpl
+++ b/internal/config/apps/scripts/integration_test/testdata/extism_inline_invalid.toml.tmpl
@@ -5,10 +5,6 @@ id = "http"
 address = "127.0.0.1:{{.Port}}"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[endpoints]]
 id = "main"
 listener_id = "http"

--- a/internal/config/apps/scripts/integration_test/testdata/extism_inline_valid.toml.tmpl
+++ b/internal/config/apps/scripts/integration_test/testdata/extism_inline_valid.toml.tmpl
@@ -5,10 +5,6 @@ id = "http"
 address = "127.0.0.1:{{.Port}}"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[endpoints]]
 id = "main"
 listener_id = "http"

--- a/internal/config/apps/scripts/integration_test/testdata/mixed_evaluators_invalid.toml.tmpl
+++ b/internal/config/apps/scripts/integration_test/testdata/mixed_evaluators_invalid.toml.tmpl
@@ -5,10 +5,6 @@ id = "http"
 address = "127.0.0.1:{{.Port}}"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[endpoints]]
 id = "main"
 listener_id = "http"

--- a/internal/config/apps/scripts/integration_test/testdata/mixed_evaluators_valid.toml.tmpl
+++ b/internal/config/apps/scripts/integration_test/testdata/mixed_evaluators_valid.toml.tmpl
@@ -5,10 +5,6 @@ id = "http"
 address = "127.0.0.1:{{.Port}}"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[endpoints]]
 id = "main"
 listener_id = "http"

--- a/internal/config/apps/scripts/integration_test/testdata/risor_file_invalid.toml.tmpl
+++ b/internal/config/apps/scripts/integration_test/testdata/risor_file_invalid.toml.tmpl
@@ -5,10 +5,6 @@ id = "http"
 address = "127.0.0.1:{{.Port}}"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[endpoints]]
 id = "main"
 listener_id = "http"

--- a/internal/config/apps/scripts/integration_test/testdata/risor_file_valid.toml.tmpl
+++ b/internal/config/apps/scripts/integration_test/testdata/risor_file_valid.toml.tmpl
@@ -5,10 +5,6 @@ id = "http"
 address = "127.0.0.1:{{.Port}}"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[endpoints]]
 id = "main"
 listener_id = "http"

--- a/internal/config/apps/scripts/integration_test/testdata/risor_inline_invalid.toml.tmpl
+++ b/internal/config/apps/scripts/integration_test/testdata/risor_inline_invalid.toml.tmpl
@@ -5,10 +5,6 @@ id = "http"
 address = "127.0.0.1:{{.Port}}"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[endpoints]]
 id = "main"
 listener_id = "http"

--- a/internal/config/apps/scripts/integration_test/testdata/risor_inline_valid.toml.tmpl
+++ b/internal/config/apps/scripts/integration_test/testdata/risor_inline_valid.toml.tmpl
@@ -5,10 +5,6 @@ id = "http"
 address = "127.0.0.1:{{.Port}}"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[endpoints]]
 id = "main"
 listener_id = "http"

--- a/internal/config/apps/scripts/integration_test/testdata/starlark_file_invalid.toml.tmpl
+++ b/internal/config/apps/scripts/integration_test/testdata/starlark_file_invalid.toml.tmpl
@@ -5,10 +5,6 @@ id = "http"
 address = "127.0.0.1:{{.Port}}"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[endpoints]]
 id = "main"
 listener_id = "http"

--- a/internal/config/apps/scripts/integration_test/testdata/starlark_file_valid.toml.tmpl
+++ b/internal/config/apps/scripts/integration_test/testdata/starlark_file_valid.toml.tmpl
@@ -5,10 +5,6 @@ id = "http"
 address = "127.0.0.1:{{.Port}}"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[endpoints]]
 id = "main"
 listener_id = "http"

--- a/internal/config/apps/scripts/integration_test/testdata/starlark_inline_invalid.toml.tmpl
+++ b/internal/config/apps/scripts/integration_test/testdata/starlark_inline_invalid.toml.tmpl
@@ -5,10 +5,6 @@ id = "http"
 address = "127.0.0.1:{{.Port}}"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[endpoints]]
 id = "main"
 listener_id = "http"

--- a/internal/config/apps/scripts/integration_test/testdata/starlark_inline_valid.toml.tmpl
+++ b/internal/config/apps/scripts/integration_test/testdata/starlark_inline_valid.toml.tmpl
@@ -5,10 +5,6 @@ id = "http"
 address = "127.0.0.1:{{.Port}}"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[endpoints]]
 id = "main"
 listener_id = "http"

--- a/internal/config/endpoints/middleware/logger/testdata/standard_preset_config.toml.tmpl
+++ b/internal/config/endpoints/middleware/logger/testdata/standard_preset_config.toml.tmpl
@@ -5,9 +5,6 @@ id = "http"
 address = "127.0.0.1:{{.Port}}"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 [[endpoints]]
 id = "main"

--- a/internal/config/listeners/proto.go
+++ b/internal/config/listeners/proto.go
@@ -2,8 +2,6 @@
 package listeners
 
 import (
-	"fmt"
-
 	pb "github.com/atlanticdynamic/firelynx/gen/settings/v1alpha1"
 	"github.com/atlanticdynamic/firelynx/internal/config/listeners/options"
 	"github.com/robbyt/protobaggins"
@@ -59,11 +57,8 @@ func FromProto(pbListeners []*pb.Listener) (ListenerCollection, error) {
 		}
 
 		// Convert protocol-specific options
-		if http := l.GetHttp(); http != nil {
-			listenerObj.Options = options.HTTPFromProto(http)
-		} else {
-			return nil, fmt.Errorf("listener '%s' has unknown protocol options", listenerObj.ID)
-		}
+		// HTTPFromProto handles nil gracefully and applies defaults
+		listenerObj.Options = options.HTTPFromProto(l.GetHttp())
 
 		listeners = append(listeners, listenerObj)
 	}

--- a/internal/config/listeners/proto_test.go
+++ b/internal/config/listeners/proto_test.go
@@ -268,16 +268,24 @@ func TestFromProto(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name: "Invalid listener with missing protocol options",
+			name: "Listener with missing protocol options gets defaults",
 			pbListeners: []*pb.Listener{
 				{
-					Id:      proto.String("invalid-listener"),
+					Id:      proto.String("listener-with-defaults"),
 					Address: proto.String("127.0.0.1:8080"),
-					// No protocol options set
+					Type:    pb.Listener_TYPE_HTTP.Enum(),
+					// No protocol options set - should get defaults
 				},
 			},
-			expected:      nil,
-			expectedError: true,
+			expected: ListenerCollection{
+				{
+					ID:      "listener-with-defaults",
+					Address: "127.0.0.1:8080",
+					Type:    TypeHTTP,
+					Options: options.NewHTTP(), // Default HTTP options
+				},
+			},
+			expectedError: false,
 		},
 		{
 			name: "Nil ID and address",

--- a/internal/config/loader/toml/testdata/endpoint_routes_array.toml
+++ b/internal/config/loader/toml/testdata/endpoint_routes_array.toml
@@ -5,11 +5,6 @@ id = "http_listener"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "1s"
-write_timeout = "1s"
-idle_timeout = "1s"
-drain_timeout = "1s"
 
 [[endpoints]]
 id = "echo_endpoint"

--- a/internal/config/loader/toml/testdata/multi_route_test.toml
+++ b/internal/config/loader/toml/testdata/multi_route_test.toml
@@ -5,11 +5,6 @@ id = "http_listener"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "1s"
-write_timeout = "1s"
-idle_timeout = "1s"
-drain_timeout = "1s"
 
 [[endpoints]]
 id = "mixed_endpoint"

--- a/internal/config/loader/toml/testdata/route_condition_test.toml
+++ b/internal/config/loader/toml/testdata/route_condition_test.toml
@@ -5,8 +5,6 @@ id = "http_listener"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "1s"
 
 [[endpoints]]
 id = "test_endpoint"

--- a/internal/config/loader/toml/testdata/single_route_object.toml
+++ b/internal/config/loader/toml/testdata/single_route_object.toml
@@ -14,10 +14,6 @@ id = "listener1"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[apps]]
 id = "app1"
 [apps.echo]

--- a/internal/config/proto_test.go
+++ b/internal/config/proto_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/atlanticdynamic/firelynx/internal/config/listeners/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 )
 
 func TestEmptyConfigToProto(t *testing.T) {
@@ -276,24 +275,6 @@ func TestConfigWithInvalidComponents(t *testing.T) {
 		createProto func() *pb.ServerConfig
 		errSubstr   string
 	}{
-		{
-			name: "Invalid Listener Options",
-			createProto: func() *pb.ServerConfig {
-				version := "v1alpha1"
-				listenerID := "invalid-listener"
-				return &pb.ServerConfig{
-					Version: &version,
-					Listeners: []*pb.Listener{
-						{
-							Id:      &listenerID,
-							Address: proto.String("127.0.0.1:8080"),
-							// No protocol options set, which is invalid
-						},
-					},
-				}
-			},
-			errSubstr: "protocol options",
-		},
 		{
 			name: "Invalid App Config",
 			createProto: func() *pb.ServerConfig {

--- a/internal/config/testdata/invalid/duplicate_ids.toml
+++ b/internal/config/testdata/invalid/duplicate_ids.toml
@@ -9,20 +9,10 @@ id = "http_listener"
 address = ":8081"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-drain_timeout = "5s"
-
 [[listeners]]
 id = "http_listener"  # Duplicate listener ID
 address = ":8082"
 type = "http"
-
-[listeners.http]
-read_timeout = "15s"
-write_timeout = "15s"
-drain_timeout = "5s"
 
 [[endpoints]]
 id = "api_endpoint"

--- a/internal/config/testdata/invalid/duplicate_route.toml
+++ b/internal/config/testdata/invalid/duplicate_route.toml
@@ -9,10 +9,6 @@ id = "http_listener"
 address = ":8081"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-drain_timeout = "5s"
 
 [[endpoints]]
 id = "api_endpoint1"

--- a/internal/config/testdata/invalid/invalid_app_id.toml
+++ b/internal/config/testdata/invalid/invalid_app_id.toml
@@ -9,10 +9,6 @@ id = "http_listener"
 address = ":8081"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-drain_timeout = "5s"
 
 [[endpoints]]
 id = "api_endpoint"

--- a/internal/config/testdata/invalid/invalid_listener_id.toml
+++ b/internal/config/testdata/invalid/invalid_listener_id.toml
@@ -9,10 +9,6 @@ id = "http_listener"
 address = ":8081"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-drain_timeout = "5s"
 
 [[endpoints]]
 id = "api_endpoint"

--- a/internal/config/testdata/invalid/invalid_version.toml
+++ b/internal/config/testdata/invalid/invalid_version.toml
@@ -8,10 +8,6 @@ format = "txt"
 id = "http_listener"
 address = ":8081"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-drain_timeout = "5s"
 
 [[endpoints]]
 id = "api_endpoint"

--- a/internal/server/integration_tests/configupdates/testdata/duplicate_endpoints.toml.tmpl
+++ b/internal/server/integration_tests/configupdates/testdata/duplicate_endpoints.toml.tmpl
@@ -5,9 +5,6 @@ id = "api"
 type = "http"
 address = "127.0.0.1:{{.Port}}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 [[endpoints]]
 id = "duplicate-endpoint"

--- a/internal/server/integration_tests/configupdates/testdata/echo_app.toml.tmpl
+++ b/internal/server/integration_tests/configupdates/testdata/echo_app.toml.tmpl
@@ -5,10 +5,6 @@ id = "api"
 type = "http"
 address = "127.0.0.1:{{.Port}}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[endpoints]]
 id = "api-endpoint"
 listener_id = "api"

--- a/internal/server/integration_tests/configupdates/testdata/initial_config.toml
+++ b/internal/server/integration_tests/configupdates/testdata/initial_config.toml
@@ -5,6 +5,3 @@ id = "http_listener"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"

--- a/internal/server/integration_tests/configupdates/testdata/route_v1_v2.toml.tmpl
+++ b/internal/server/integration_tests/configupdates/testdata/route_v1_v2.toml.tmpl
@@ -5,9 +5,6 @@ id = "api"
 type = "http"
 address = "127.0.0.1:{{.Port}}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 [[endpoints]]
 id = "api-endpoint"

--- a/internal/server/integration_tests/configupdates/testdata/updated_config.toml
+++ b/internal/server/integration_tests/configupdates/testdata/updated_config.toml
@@ -5,6 +5,3 @@ id = "http_listener_updated"
 address = ":8081"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"

--- a/internal/server/integration_tests/http/http_minimal_test.go
+++ b/internal/server/integration_tests/http/http_minimal_test.go
@@ -144,10 +144,6 @@ version = "v1"
 id = "http-1"
 type = "http"
 address = "127.0.0.1:0"
-
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 `
 	config2, err := config.NewConfigFromBytes([]byte(config2Data))
 	require.NoError(t, err)

--- a/internal/server/integration_tests/http/testdata/duplicate_ports.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/duplicate_ports.toml.tmpl
@@ -5,15 +5,8 @@ id = "listener1"
 type = "http"
 address = "127.0.0.1:{{.Port}}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 [[listeners]]
 id = "listener2"
 type = "http"
 address = "127.0.0.1:{{.Port}}"
-
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"

--- a/internal/server/integration_tests/http/testdata/echo_app.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/echo_app.toml.tmpl
@@ -5,9 +5,6 @@ id = "api"
 type = "http"
 address = "127.0.0.1:{{.Port}}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 [[endpoints]]
 id = "api-endpoint"

--- a/internal/server/integration_tests/http/testdata/headers_integration.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/headers_integration.toml.tmpl
@@ -8,9 +8,6 @@ id = "http"
 address = "127.0.0.1:{{.Port}}"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 # Set Headers Endpoint - Replace existing headers
 [[endpoints]]

--- a/internal/server/integration_tests/http/testdata/invalid_address.toml
+++ b/internal/server/integration_tests/http/testdata/invalid_address.toml
@@ -5,6 +5,3 @@ id = "bad-listener"
 type = "http"
 address = "not-a-valid-address"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"

--- a/internal/server/integration_tests/http/testdata/listener_with_route.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/listener_with_route.toml.tmpl
@@ -5,10 +5,6 @@ id = "http-1"
 type = "http"
 address = "127.0.0.1:{{.Port}}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[endpoints]]
 id = "test-endpoint"
 listener_id = "http-1"

--- a/internal/server/integration_tests/http/testdata/logger_integration.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/logger_integration.toml.tmpl
@@ -8,9 +8,6 @@ id = "http"
 address = "127.0.0.1:{{.Port}}"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 # Main Endpoint with Standard Logger
 [[endpoints]]

--- a/internal/server/integration_tests/http/testdata/logging.toml
+++ b/internal/server/integration_tests/http/testdata/logging.toml
@@ -5,9 +5,6 @@ id = "http"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 [[endpoints]]
 id = "main"

--- a/internal/server/integration_tests/http/testdata/one_listener.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/one_listener.toml.tmpl
@@ -5,6 +5,3 @@ id = "http-1"
 type = "http"
 address = "127.0.0.1:{{.Port1}}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"

--- a/internal/server/integration_tests/http/testdata/route_v1.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/route_v1.toml.tmpl
@@ -5,9 +5,6 @@ id = "api"
 type = "http"
 address = "127.0.0.1:{{.Port}}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 [[endpoints]]
 id = "api-endpoint"

--- a/internal/server/integration_tests/http/testdata/route_v1_v2.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/route_v1_v2.toml.tmpl
@@ -5,9 +5,6 @@ id = "api"
 type = "http"
 address = "127.0.0.1:{{.Port}}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 [[endpoints]]
 id = "api-endpoint"

--- a/internal/server/integration_tests/http/testdata/script_extism_basic.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/script_extism_basic.toml.tmpl
@@ -5,9 +5,6 @@ id = "api"
 type = "http"
 address = "127.0.0.1:{{.Port}}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 [[endpoints]]
 id = "api-endpoint"

--- a/internal/server/integration_tests/http/testdata/script_extism_https.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/script_extism_https.toml.tmpl
@@ -5,9 +5,6 @@ id = "api"
 type = "http"
 address = "127.0.0.1:{{.Port}}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 [[endpoints]]
 id = "api-endpoint"

--- a/internal/server/integration_tests/http/testdata/script_risor_basic.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/script_risor_basic.toml.tmpl
@@ -5,9 +5,6 @@ id = "api"
 type = "http"
 address = "127.0.0.1:{{.Port}}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 [[endpoints]]
 id = "api-endpoint"

--- a/internal/server/integration_tests/http/testdata/script_risor_file_uri.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/script_risor_file_uri.toml.tmpl
@@ -5,9 +5,6 @@ id = "api"
 type = "http"
 address = "127.0.0.1:{{.Port}}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 [[endpoints]]
 id = "api-endpoint"

--- a/internal/server/integration_tests/http/testdata/script_risor_https.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/script_risor_https.toml.tmpl
@@ -5,9 +5,6 @@ id = "api"
 type = "http"
 address = "127.0.0.1:{{.Port}}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 [[endpoints]]
 id = "api-endpoint"

--- a/internal/server/integration_tests/http/testdata/script_starlark_basic.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/script_starlark_basic.toml.tmpl
@@ -5,9 +5,6 @@ id = "api"
 type = "http"
 address = "127.0.0.1:{{.Port}}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 [[endpoints]]
 id = "api-endpoint"

--- a/internal/server/integration_tests/http/testdata/script_starlark_file_uri.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/script_starlark_file_uri.toml.tmpl
@@ -5,9 +5,6 @@ id = "api"
 type = "http"
 address = "127.0.0.1:{{.Port}}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 [[endpoints]]
 id = "api-endpoint"

--- a/internal/server/integration_tests/http/testdata/script_starlark_https.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/script_starlark_https.toml.tmpl
@@ -5,9 +5,6 @@ id = "api"
 type = "http"
 address = "127.0.0.1:{{.Port}}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 [[endpoints]]
 id = "api-endpoint"

--- a/internal/server/integration_tests/http/testdata/script_syntax_error.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/script_syntax_error.toml.tmpl
@@ -5,9 +5,6 @@ id = "api"
 type = "http"
 address = "127.0.0.1:{{.Port}}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 [[endpoints]]
 id = "api-endpoint"

--- a/internal/server/integration_tests/http/testdata/single_logger.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/single_logger.toml.tmpl
@@ -5,9 +5,6 @@ id = "http"
 address = "127.0.0.1:{{.Port}}"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 [[endpoints]]
 id = "main"

--- a/internal/server/integration_tests/http/testdata/static_data_risor.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/static_data_risor.toml.tmpl
@@ -5,9 +5,6 @@ id = "api"
 type = "http"
 address = "127.0.0.1:{{ .Port }}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
 
 [[endpoints]]
 id = "api-endpoint"

--- a/internal/server/integration_tests/http/testdata/two_listeners.toml.tmpl
+++ b/internal/server/integration_tests/http/testdata/two_listeners.toml.tmpl
@@ -5,15 +5,7 @@ id = "http-1"
 type = "http"
 address = "127.0.0.1:{{.Port1}}"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-
 [[listeners]]
 id = "http-2"
 type = "http"
 address = "127.0.0.1:{{.Port2}}"
-
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"

--- a/internal/server/runnables/cfgfileloader/testdata/updated_config.toml
+++ b/internal/server/runnables/cfgfileloader/testdata/updated_config.toml
@@ -5,10 +5,6 @@ id = "updated"
 address = ":9090"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-drain_timeout = "5s"
 
 [[apps]]
 id = "echo"

--- a/internal/server/runnables/cfgfileloader/testdata/valid_config.toml
+++ b/internal/server/runnables/cfgfileloader/testdata/valid_config.toml
@@ -5,10 +5,6 @@ id = "test"
 address = ":8080"
 type = "http"
 
-[listeners.http]
-read_timeout = "30s"
-write_timeout = "30s"
-drain_timeout = "5s"
 
 [[apps]]
 id = "echo"


### PR DESCRIPTION
This change also updates all the example and fixture configs to remove the http listener timeouts if they're not actually needed or tested.