### PR TITLE
remove golines from the formatters, it's conflicting with the auto-fix on tagalign

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,24 +12,25 @@ linters:
     - noctx         # Finds sending http request without context.Context
     - prealloc      # Temporarily disable until slice allocation issues are fixed
   enable:
-    - bodyclose     # Checks HTTP response body is closed
-    - contextcheck  # Check whether the function uses a non-inherited context
-    - dupl          # Find duplicate code
-    - dupword       # Find duplicate words in comments and strings
-    - errcheck
-    - errorlint     # Check error handling
-    - misspell      # Find commonly misspelled English words
-    - unconvert     # Remove unnecessary type conversions
-    - reassign      # Checks that package variables are not reassigned
-    - tagalign      # Check that struct tags are well aligned
-    - nilerr        # Finds code that returns nil even if it checks that the error is not nil
-    - nolintlint    # Checks for invalid or missing nolint directives
-    - whitespace    # Check for unnecessary whitespace
-    - thelper       # Detects test helpers which should start with t.Helper()
-    - govet         # Examines Go source code and reports suspicious constructs
-    - ineffassign   # Detects when assignments to existing variables are not used
-    - staticcheck   # Staticcheck is a go linter
-    - unused        # Checks for unused code
+    - bodyclose      # Ensure HTTP response bodies are closed
+    - contextcheck   # Ensure functions use a non-inherited context
+    - dupl           # Detect duplicate code
+    - dupword        # Detect duplicate words in comments/strings
+    - errcheck       # Check for unchecked errors
+    - errorlint      # Enforce idiomatic error handling
+    - govet          # Report suspicious constructs
+    - ineffassign    # Detect unused variable assignments
+    - misspell       # Detect misspelled English words
+    - nilerr         # Detect returning nil after error checks
+    - nolintlint     # Check for invalid/missing nolint directives
+    - reassign       # Prevent package variable reassignment
+    - staticcheck    # Advanced static analysis
+    - tagalign       # Check struct tag alignment
+    - tagliatelle    # Enforce struct tag formatting
+    - thelper        # Ensure test helpers use t.Helper()
+    - unconvert      # Remove unnecessary type conversions
+    - unused         # Detect unused code
+    - whitespace     # Detect unnecessary whitespace
   settings:
     errcheck:
       check-blank: true
@@ -41,6 +42,14 @@ linters:
       errorf: true
       asserts: true
       comparison: true
+    tagalign:
+      strict: true
+      order:
+        - json
+        - toml
+        - yaml
+        - xml
+        - env_interpolation
 
 formatters:
   enable:
@@ -48,7 +57,6 @@ formatters:
     - gofmt
     - goimports
     - gofumpt
-    - golines
 
 issues:
   max-issues-per-linter: 20

--- a/cmd/firelynx/client/client.go
+++ b/cmd/firelynx/client/client.go
@@ -161,7 +161,7 @@ func ListTransactions(
 	case "json":
 		response := struct {
 			Transactions  any    `json:"transactions"`
-			NextPageToken string `json:"next_page_token,omitempty"`
+			NextPageToken string `json:"nextPageToken,omitempty"`
 		}{
 			Transactions:  transactions,
 			NextPageToken: nextPageToken,

--- a/internal/server/runnables/cfgservice/runner.go
+++ b/internal/server/runnables/cfgservice/runner.go
@@ -226,7 +226,7 @@ func (r *Runner) GetDomainConfig() config.Config {
 // pageToken represents the internal structure of a pagination token
 type pageToken struct {
 	Offset   int    `json:"offset"`
-	PageSize int    `json:"page_size"`
+	PageSize int    `json:"pageSize"`
 	State    string `json:"state,omitempty"`
 	Source   string `json:"source,omitempty"`
 }


### PR DESCRIPTION
lint warnings in #67 were being caused by a conflict between the `tagalign` and `golines` formatter.