### PR TITLE
simplify App interface by removing staticData parameter

### DIFF
--- a/internal/server/apps/app.go
+++ b/internal/server/apps/app.go
@@ -17,6 +17,5 @@ type App interface {
 		ctx context.Context,
 		resp http.ResponseWriter,
 		req *http.Request,
-		data map[string]any,
 	) error
 }

--- a/internal/server/apps/echo/echo.go
+++ b/internal/server/apps/echo/echo.go
@@ -30,7 +30,6 @@ func (a *App) HandleHTTP(
 	ctx context.Context,
 	w http.ResponseWriter,
 	r *http.Request,
-	staticData map[string]any,
 ) error {
 	// Set content type to plain text for simple response
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")

--- a/internal/server/apps/echo/echo_test.go
+++ b/internal/server/apps/echo/echo_test.go
@@ -85,7 +85,7 @@ func TestEchoApp_HandleHTTP(t *testing.T) {
 			rr := httptest.NewRecorder()
 
 			// Call the handler directly
-			err := app.HandleHTTP(t.Context(), rr, req, tt.staticData)
+			err := app.HandleHTTP(t.Context(), rr, req)
 			require.NoError(t, err, "HandleHTTP should not return an error")
 
 			// Get the result from the recorder
@@ -125,7 +125,7 @@ func TestEchoApp_HandleHTTP_WriteError(t *testing.T) {
 		header: http.Header{},
 	}
 
-	err := app.HandleHTTP(t.Context(), failWriter, r, nil)
+	err := app.HandleHTTP(t.Context(), failWriter, r)
 	require.Error(t, err, "HandleHTTP should return an error when write fails")
 	assert.Contains(
 		t,

--- a/internal/server/apps/instantiators_test.go
+++ b/internal/server/apps/instantiators_test.go
@@ -34,7 +34,6 @@ func (m *MockApp) HandleHTTP(
 	ctx context.Context,
 	w http.ResponseWriter,
 	r *http.Request,
-	data map[string]any,
 ) error {
 	return nil
 }
@@ -98,7 +97,7 @@ func TestCreateEchoApp(t *testing.T) {
 			r := httptest.NewRequest("GET", "/test", nil)
 			ctx := t.Context()
 
-			err = echoApp.HandleHTTP(ctx, w, r, nil)
+			err = echoApp.HandleHTTP(ctx, w, r)
 			require.NoError(t, err)
 
 			// Verify the response matches expected
@@ -261,7 +260,7 @@ _ = result`,
 
 				// Note: We don't require HandleHTTP to succeed since that depends on
 				// script content and execution, but we verify it doesn't panic
-				err := scriptApp.HandleHTTP(ctx, w, r, nil)
+				err := scriptApp.HandleHTTP(ctx, w, r)
 				_ = err // Intentionally ignore error in smoke test
 			}
 		})
@@ -532,7 +531,7 @@ func TestCreateMCPApp(t *testing.T) {
 
 				// Note: We don't require HandleHTTP to succeed since that depends on
 				// MCP SDK implementation, but we verify it doesn't panic
-				err := mcpApp.HandleHTTP(ctx, w, r, nil)
+				err := mcpApp.HandleHTTP(ctx, w, r)
 				_ = err // Intentionally ignore error in smoke test
 			}
 		})

--- a/internal/server/apps/mcp/mcp.go
+++ b/internal/server/apps/mcp/mcp.go
@@ -46,7 +46,6 @@ func (a *App) HandleHTTP(
 	ctx context.Context,
 	w http.ResponseWriter,
 	r *http.Request,
-	staticData map[string]any,
 ) error {
 	// The MCP SDK handler manages all MCP protocol concerns
 	// We simply delegate the request to it

--- a/internal/server/apps/mcp/mcp_test.go
+++ b/internal/server/apps/mcp/mcp_test.go
@@ -110,10 +110,9 @@ func TestApp_HandleHTTP(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/test", nil)
 		w := httptest.NewRecorder()
 		ctx := t.Context()
-		staticData := map[string]any{}
 
 		// HandleHTTP should not return an error (MCP SDK handles errors internally)
-		err = app.HandleHTTP(ctx, w, req, staticData)
+		err = app.HandleHTTP(ctx, w, req)
 		assert.NoError(t, err)
 
 		// The actual response depends on MCP SDK implementation
@@ -131,11 +130,10 @@ func TestApp_HandleHTTP(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/test", nil)
 		w := httptest.NewRecorder()
 		ctx := t.Context()
-		staticData := map[string]any{}
 
 		// Should panic with nil handler
 		assert.Panics(t, func() {
-			app.HandleHTTP(ctx, w, req, staticData) //nolint:errcheck // Expected to panic
+			app.HandleHTTP(ctx, w, req) //nolint:errcheck // Expected to panic
 		})
 	})
 }
@@ -183,7 +181,7 @@ func TestApp_Integration(t *testing.T) {
 		w := httptest.NewRecorder()
 		ctx := t.Context()
 
-		err = app.HandleHTTP(ctx, w, req, map[string]any{})
+		err = app.HandleHTTP(ctx, w, req)
 		assert.NoError(t, err)
 
 		// Response handling is delegated to MCP SDK

--- a/internal/server/apps/mocks/app.go
+++ b/internal/server/apps/mocks/app.go
@@ -32,8 +32,7 @@ func (m *MockApp) HandleHTTP(
 	ctx context.Context,
 	w http.ResponseWriter,
 	r *http.Request,
-	params map[string]any,
 ) error {
-	args := m.Called(ctx, w, r, params)
+	args := m.Called(ctx, w, r)
 	return args.Error(0)
 }

--- a/internal/server/apps/mocks/app_test.go
+++ b/internal/server/apps/mocks/app_test.go
@@ -29,15 +29,13 @@ func TestMockApp(t *testing.T) {
 	r, err := http.NewRequest(http.MethodGet, "/test", nil)
 	require.NoError(t, err)
 
-	params := map[string]any{"key": "value"}
-
 	// Set expectation for HandleHTTP to be called with specific arguments
 	// and return a specific error
 	expectedError := errors.New("test error")
-	mockApp.On("HandleHTTP", ctx, w, r, params).Return(expectedError).Once()
+	mockApp.On("HandleHTTP", ctx, w, r).Return(expectedError).Once()
 
 	// Call the method
-	result := mockApp.HandleHTTP(ctx, w, r, params)
+	result := mockApp.HandleHTTP(ctx, w, r)
 
 	// Assert expectations
 	assert.Equal(t, expectedError, result)
@@ -46,7 +44,7 @@ func TestMockApp(t *testing.T) {
 	// Test with custom behavior
 	customMock := &mocks.MockApp{}
 	customMock.On("String").Return("custom-id")
-	customMock.On("HandleHTTP", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	customMock.On("HandleHTTP", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			// Extract arguments
 			writer := args.Get(1).(http.ResponseWriter)
@@ -62,7 +60,7 @@ func TestMockApp(t *testing.T) {
 
 	// Test HandleHTTP custom behavior
 	newRecorder := httptest.NewRecorder()
-	err = customMock.HandleHTTP(ctx, newRecorder, r, nil)
+	err = customMock.HandleHTTP(ctx, newRecorder, r)
 
 	// Verify results
 	assert.NoError(t, err)

--- a/internal/server/apps/script/script_test.go
+++ b/internal/server/apps/script/script_test.go
@@ -124,7 +124,7 @@ func TestScriptApp_HandleHTTP_RisorScript(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	w := httptest.NewRecorder()
 
-	err = app.HandleHTTP(t.Context(), w, req, nil)
+	err = app.HandleHTTP(t.Context(), w, req)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
@@ -159,11 +159,7 @@ func TestScriptApp_HandleHTTP_WithStaticData(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	w := httptest.NewRecorder()
 
-	runtimeData := map[string]any{
-		"runtime_key": "runtime_value",
-	}
-
-	err = app.HandleHTTP(t.Context(), w, req, runtimeData)
+	err = app.HandleHTTP(t.Context(), w, req)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "static_value")
@@ -211,7 +207,7 @@ func TestScriptApp_HandleHTTP_Timeout(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	w := httptest.NewRecorder()
 
-	err = app.HandleHTTP(t.Context(), w, req, nil)
+	err = app.HandleHTTP(t.Context(), w, req)
 	assert.Error(t, err)
 	assert.Equal(t, http.StatusGatewayTimeout, w.Code)
 }
@@ -242,7 +238,7 @@ _ = result`,
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	w := httptest.NewRecorder()
 
-	err = app.HandleHTTP(t.Context(), w, req, nil)
+	err = app.HandleHTTP(t.Context(), w, req)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
@@ -282,7 +278,7 @@ _ = result`,
 	req := httptest.NewRequest(http.MethodPost, "/api/test", nil)
 	w := httptest.NewRecorder()
 
-	err = app.HandleHTTP(t.Context(), w, req, nil)
+	err = app.HandleHTTP(t.Context(), w, req)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "production")
@@ -310,7 +306,7 @@ func TestScriptApp_HandleHTTP_PrepareScriptDataError(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	// This should work fine since prepareScriptData doesn't fail for valid inputs
-	err = app.HandleHTTP(t.Context(), w, req, nil)
+	err = app.HandleHTTP(t.Context(), w, req)
 	assert.NoError(t, err)
 }
 
@@ -346,7 +342,7 @@ func TestScriptApp_HandleHTTP_ExtismDataStructure(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	// For non-Extism evaluators, data field should be available as-is
-	err = app.HandleHTTP(t.Context(), w, req, nil)
+	err = app.HandleHTTP(t.Context(), w, req)
 	assert.NoError(t, err)
 }
 
@@ -369,7 +365,7 @@ func TestScriptApp_HandleHTTP_StringResult(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	w := httptest.NewRecorder()
 
-	err = app.HandleHTTP(t.Context(), w, req, nil)
+	err = app.HandleHTTP(t.Context(), w, req)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
@@ -395,7 +391,7 @@ func TestScriptApp_HandleHTTP_NumericResult(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	w := httptest.NewRecorder()
 
-	err = app.HandleHTTP(t.Context(), w, req, nil)
+	err = app.HandleHTTP(t.Context(), w, req)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
@@ -424,7 +420,7 @@ func TestScriptApp_HandleHTTP_ExecutionError(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	w := httptest.NewRecorder()
 
-	err = app.HandleHTTP(t.Context(), w, req, nil)
+	err = app.HandleHTTP(t.Context(), w, req)
 	assert.Error(t, err)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }

--- a/internal/server/integration_tests/http/http_test.go
+++ b/internal/server/integration_tests/http/http_test.go
@@ -46,7 +46,7 @@ func TestIntegration_HTTP(t *testing.T) {
 
 	// Create mock apps
 	echoApp := mocks.NewMockApp("echo-app")
-	echoApp.On("HandleHTTP", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	echoApp.On("HandleHTTP", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil).
 		Run(func(args mock.Arguments) {
 			w := args.Get(1).(http.ResponseWriter)
@@ -56,7 +56,7 @@ func TestIntegration_HTTP(t *testing.T) {
 		})
 
 	adminApp := mocks.NewMockApp("admin-app")
-	adminApp.On("HandleHTTP", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	adminApp.On("HandleHTTP", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil).
 		Run(func(args mock.Arguments) {
 			w := args.Get(1).(http.ResponseWriter)
@@ -84,14 +84,14 @@ func TestIntegration_HTTP(t *testing.T) {
 	// Create echo route handler
 	echoHandler := func(w http.ResponseWriter, r *http.Request) {
 		// Call echo app directly
-		err := echoApp.HandleHTTP(r.Context(), w, r, map[string]any{"version": "1.0"})
+		err := echoApp.HandleHTTP(r.Context(), w, r)
 		require.NoError(t, err)
 	}
 
 	// Create admin route handler
 	adminHandler := func(w http.ResponseWriter, r *http.Request) {
 		// Call admin app directly
-		err := adminApp.HandleHTTP(r.Context(), w, r, map[string]any{"role": "admin"})
+		err := adminApp.HandleHTTP(r.Context(), w, r)
 		require.NoError(t, err)
 	}
 

--- a/internal/server/runnables/listeners/http/cfg/adapter.go
+++ b/internal/server/runnables/listeners/http/cfg/adapter.go
@@ -237,11 +237,8 @@ func extractEndpointRoutes(
 
 		// Create a handler function for this route
 		handlerFunc := func(w http.ResponseWriter, r *http.Request) {
-			// Expanded app already has merged static data
-			data := make(map[string]any)
-
 			// Call the app handler
-			err := app.HandleHTTP(r.Context(), w, r, data)
+			err := app.HandleHTTP(r.Context(), w, r)
 			if err != nil {
 				logger.Error("Error handling request",
 					"path", r.URL.Path,

--- a/internal/server/runnables/listeners/http/cfg/adapter_test.go
+++ b/internal/server/runnables/listeners/http/cfg/adapter_test.go
@@ -666,7 +666,7 @@ func TestExtractEndpointRoutesErrorHandling(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/api/error", nil)
 
-	expandedErrorApp.On("HandleHTTP", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	expandedErrorApp.On("HandleHTTP", mock.Anything, mock.Anything, mock.Anything).
 		Return(errors.New("app error")).
 		Once()
 
@@ -727,14 +727,11 @@ func TestExtractEndpointRoutesWithStaticData(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, routes, 1)
 
-	// Test that static data is passed to the app
+	// Test that app is called without static data parameter
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/api/test", nil)
 
-	expandedServerApp.On("HandleHTTP", mock.Anything, mock.Anything, mock.Anything, mock.MatchedBy(func(data map[string]any) bool {
-		// Expanded app should receive empty data map since static data is merged in the app instance
-		return len(data) == 0
-	})).
+	expandedServerApp.On("HandleHTTP", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil).
 		Once()
 


### PR DESCRIPTION
This change removes the unused `data map[string]any` parameter from the App interface's HandleHTTP method. Static data is now embedded during app creation rather than being passed at runtime, making this parameter unnecessary.