### PR TITLE
move app expansion from proto conversion to validation phase

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,8 +111,6 @@ func NewFromProto(pbConfig *pb.ServerConfig) (*Config, error) {
 			appErrz = append(appErrz, fmt.Errorf("failed to convert apps: %w", err))
 		} else {
 			config.Apps = appDefinitions
-			// Assign app instances to routes with merged static data
-			expandAppsForRoutes(config.Apps, config.Endpoints)
 		}
 	}
 

--- a/internal/config/proto.go
+++ b/internal/config/proto.go
@@ -62,8 +62,6 @@ func fromProto(pbConfig *pb.ServerConfig) (*Config, error) {
 			return nil, fmt.Errorf("%w: %w", ErrFailedToConvertConfig, err)
 		}
 		config.Apps = appDefinitions
-		// Assign app instances to routes with merged static data
-		expandAppsForRoutes(config.Apps, config.Endpoints)
 	}
 
 	return config, nil

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -38,6 +38,10 @@ func (c *Config) Validate() error {
 	endpointErrs := c.validateEndpoints(listenerIds)
 	errs = append(errs, endpointErrs...)
 
+	// Expand apps for routes before validating them
+	// This creates route-specific app instances with merged static data
+	expandAppsForRoutes(c.Apps, c.Endpoints)
+
 	// Validate apps and route references
 	if err := c.validateAppsAndRoutes(); err != nil {
 		errs = append(errs, err)


### PR DESCRIPTION
This change corrects the initialization order by moving app expansion to the validation phase where it belongs. This ensures apps are properly expanded before validation runs on the expanded instances.