### PR TITLE
use config constructor in test files instead of direct struct instantiation

### DIFF
--- a/internal/config/transaction/constructors_test.go
+++ b/internal/config/transaction/constructors_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	pb "github.com/atlanticdynamic/firelynx/gen/settings/v1alpha1"
 	"github.com/atlanticdynamic/firelynx/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,9 +20,9 @@ func TestConstructors(t *testing.T) {
 	t.Parallel()
 
 	handler := slog.NewTextHandler(os.Stdout, nil)
-	cfg := &config.Config{
-		Version: config.VersionLatest,
-	}
+	cfg, err := config.NewFromProto(&pb.ServerConfig{})
+	require.NoError(t, err)
+	cfg.Version = config.VersionLatest
 
 	t.Run("constructs from file", func(t *testing.T) {
 		tmpDir := t.TempDir()

--- a/internal/config/transaction/transaction_test.go
+++ b/internal/config/transaction/transaction_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	pb "github.com/atlanticdynamic/firelynx/gen/settings/v1alpha1"
 	"github.com/atlanticdynamic/firelynx/internal/config"
 	"github.com/atlanticdynamic/firelynx/internal/config/apps"
 	"github.com/atlanticdynamic/firelynx/internal/config/apps/echo"
@@ -34,9 +35,9 @@ func setupTest(t *testing.T) (*ConfigTransaction, slog.Handler) {
 
 	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})
 	// Create a valid config with the current version
-	cfg := &config.Config{
-		Version: config.VersionLatest,
-	}
+	cfg, err := config.NewFromProto(&pb.ServerConfig{})
+	require.NoError(t, err)
+	cfg.Version = config.VersionLatest
 
 	tx, err := FromTest("test_transaction", cfg, handler)
 	require.NoError(t, err)

--- a/internal/server/runnables/cfgservice/runner_config_test.go
+++ b/internal/server/runnables/cfgservice/runner_config_test.go
@@ -1035,10 +1035,11 @@ func createTestTransaction(
 	state string,
 ) *transaction.ConfigTransaction {
 	t.Helper()
-	cfg := &config.Config{Version: version.Version}
+	cfg, err := config.NewFromProto(&pb.ServerConfig{})
+	require.NoError(t, err)
+	cfg.Version = version.Version
 
 	var tx *transaction.ConfigTransaction
-	var err error
 
 	switch source {
 	case transaction.SourceAPI:
@@ -1409,7 +1410,9 @@ func TestGetCurrentConfigTransaction(t *testing.T) {
 		h.transitionToRunning()
 
 		// Create and set a current transaction
-		cfg := &config.Config{Version: version.Version}
+		cfg, err := config.NewFromProto(&pb.ServerConfig{})
+		require.NoError(t, err)
+		cfg.Version = version.Version
 		tx, err := transaction.FromAPI("test-request", cfg, handler)
 		require.NoError(t, err)
 		require.NoError(t, tx.RunValidation())
@@ -1488,7 +1491,9 @@ func TestGetCurrentConfigTransaction(t *testing.T) {
 
 		for _, tt := range states {
 			t.Run(tt.name, func(t *testing.T) {
-				cfg := &config.Config{Version: version.Version}
+				cfg, err := config.NewFromProto(&pb.ServerConfig{})
+				require.NoError(t, err)
+				cfg.Version = version.Version
 				tx, err := transaction.FromTest("test-tx", cfg, handler)
 				require.NoError(t, err)
 
@@ -1522,7 +1527,9 @@ func TestGetConfigTransaction(t *testing.T) {
 		h.transitionToRunning()
 
 		// Create a transaction and add it to storage
-		cfg := &config.Config{Version: version.Version}
+		cfg, err := config.NewFromProto(&pb.ServerConfig{})
+		require.NoError(t, err)
+		cfg.Version = version.Version
 		tx, err := transaction.FromAPI("test-request", cfg, handler)
 		require.NoError(t, err)
 		require.NoError(t, tx.RunValidation())
@@ -1616,7 +1623,9 @@ func TestGetConfigTransaction(t *testing.T) {
 			{
 				name: "API source",
 				createTx: func() (*transaction.ConfigTransaction, error) {
-					cfg := &config.Config{Version: version.Version}
+					cfg, err := config.NewFromProto(&pb.ServerConfig{})
+					require.NoError(t, err)
+					cfg.Version = version.Version
 					return transaction.FromAPI("api-request", cfg, handler)
 				},
 				expectedSource: pb.ConfigTransaction_SOURCE_API,
@@ -1624,7 +1633,9 @@ func TestGetConfigTransaction(t *testing.T) {
 			{
 				name: "Test source",
 				createTx: func() (*transaction.ConfigTransaction, error) {
-					cfg := &config.Config{Version: version.Version}
+					cfg, err := config.NewFromProto(&pb.ServerConfig{})
+					require.NoError(t, err)
+					cfg.Version = version.Version
 					return transaction.FromTest("test-tx", cfg, handler)
 				},
 				expectedSource: pb.ConfigTransaction_SOURCE_TEST,
@@ -1663,7 +1674,9 @@ func TestClearConfigTransactions(t *testing.T) {
 		h.transitionToRunning()
 
 		// Add multiple transactions to storage
-		cfg := &config.Config{Version: version.Version}
+		cfg, err := config.NewFromProto(&pb.ServerConfig{})
+		require.NoError(t, err)
+		cfg.Version = version.Version
 		for range 5 {
 			tx, err := transaction.FromTest("test-tx", cfg, handler)
 			require.NoError(t, err)
@@ -1693,7 +1706,9 @@ func TestClearConfigTransactions(t *testing.T) {
 		h.transitionToRunning()
 
 		// Add multiple transactions
-		cfg := &config.Config{Version: version.Version}
+		cfg, err := config.NewFromProto(&pb.ServerConfig{})
+		require.NoError(t, err)
+		cfg.Version = version.Version
 		for range 10 {
 			tx, err := transaction.FromTest("test-tx", cfg, handler)
 			require.NoError(t, err)
@@ -1720,7 +1735,9 @@ func TestClearConfigTransactions(t *testing.T) {
 		h.transitionToRunning()
 
 		// Add transactions
-		cfg := &config.Config{Version: version.Version}
+		cfg, err := config.NewFromProto(&pb.ServerConfig{})
+		require.NoError(t, err)
+		cfg.Version = version.Version
 		for range 3 {
 			tx, err := transaction.FromTest("test-tx", cfg, handler)
 			require.NoError(t, err)
@@ -1800,7 +1817,9 @@ func TestClearConfigTransactions(t *testing.T) {
 				h.txStorage.transactions = nil
 
 				// Add specified number of transactions
-				cfg := &config.Config{Version: version.Version}
+				cfg, err := config.NewFromProto(&pb.ServerConfig{})
+				require.NoError(t, err)
+				cfg.Version = version.Version
 				for range tt.transactionCount {
 					tx, err := transaction.FromTest("test-tx", cfg, handler)
 					require.NoError(t, err)

--- a/internal/server/runnables/listeners/http/runner_test.go
+++ b/internal/server/runnables/listeners/http/runner_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	pb "github.com/atlanticdynamic/firelynx/gen/settings/v1alpha1"
 	"github.com/atlanticdynamic/firelynx/internal/config"
 	"github.com/atlanticdynamic/firelynx/internal/config/transaction"
 	"github.com/stretchr/testify/assert"
@@ -14,9 +15,12 @@ import (
 
 // For testing only - a minimal config
 func mockConfig() *config.Config {
-	return &config.Config{
-		Version: "v1",
+	cfg, err := config.NewFromProto(&pb.ServerConfig{})
+	if err != nil {
+		panic("failed to create mock config: " + err.Error())
 	}
+	cfg.Version = config.VersionLatest
+	return cfg
 }
 
 // setupAppsInTransaction runs validation to create apps in the transaction

--- a/internal/server/runnables/txmgr/orchestrator/saga_test.go
+++ b/internal/server/runnables/txmgr/orchestrator/saga_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 
+	pb "github.com/atlanticdynamic/firelynx/gen/settings/v1alpha1"
 	"github.com/atlanticdynamic/firelynx/internal/config"
 	"github.com/atlanticdynamic/firelynx/internal/config/transaction"
 	"github.com/atlanticdynamic/firelynx/internal/config/transaction/finitestate"
@@ -178,7 +179,9 @@ func TestProcessTransaction_Success(t *testing.T) {
 	ctx := t.Context()
 
 	// Create a test transaction
-	cfg := &config.Config{Version: "v1"}
+	cfg, err := config.NewFromProto(&pb.ServerConfig{})
+	require.NoError(t, err)
+	cfg.Version = config.VersionLatest
 	tx, err := transaction.New(transaction.SourceTest, "test", "req-123", cfg, handler)
 	require.NoError(t, err)
 
@@ -225,7 +228,9 @@ func TestProcessTransaction_Failure(t *testing.T) {
 	ctx := t.Context()
 
 	// Create a test transaction
-	cfg := &config.Config{Version: "v1"}
+	cfg, err := config.NewFromProto(&pb.ServerConfig{})
+	require.NoError(t, err)
+	cfg.Version = config.VersionLatest
 	tx, err := transaction.New(transaction.SourceTest, "test", "req-123", cfg, handler)
 	require.NoError(t, err)
 
@@ -270,7 +275,9 @@ func TestCompensateParticipants(t *testing.T) {
 	ctx := t.Context()
 
 	// Create a test transaction
-	cfg := &config.Config{Version: "v1"}
+	cfg, err := config.NewFromProto(&pb.ServerConfig{})
+	require.NoError(t, err)
+	cfg.Version = config.VersionLatest
 	tx, err := transaction.New(transaction.SourceTest, "test", "req-123", cfg, handler)
 	require.NoError(t, err)
 
@@ -323,7 +330,8 @@ func TestGetTransactionStatus(t *testing.T) {
 	orchestrator := NewSagaOrchestrator(storage, handler)
 
 	// Create a test transaction
-	cfg := &config.Config{}
+	cfg, err := config.NewFromProto(&pb.ServerConfig{})
+	require.NoError(t, err)
 	tx, err := transaction.New(transaction.SourceTest, "test-details", "req-456", cfg, handler)
 	require.NoError(t, err)
 
@@ -401,9 +409,9 @@ func TestProcessTransactionWithNoParticipants(t *testing.T) {
 	ctx := t.Context()
 
 	// Create a minimal config for testing
-	cfg := &config.Config{
-		Version: "v1",
-	}
+	cfg, err := config.NewFromProto(&pb.ServerConfig{})
+	require.NoError(t, err)
+	cfg.Version = config.VersionLatest
 
 	// Create and validate transaction
 	tx, err := transaction.New(


### PR DESCRIPTION
This replaces direct Config struct instantiation with proper constructor usage across test files, ensuring test configurations use the `config.NewFromProto(&pb.ServerConfig{})` constructor followed by field assignments rather than direct struct literals. This is a prerequisite for the upcoming `AppCollection` refactoring in PR #79.