### PR TITLE
adjust validate output for middleware

### DIFF
--- a/internal/config/endpoints/middleware/headers/proto.go
+++ b/internal/config/endpoints/middleware/headers/proto.go
@@ -38,13 +38,14 @@ func (h *Headers) ToProto() any {
 	return config
 }
 
-// convertHeaderOperations converts protobuf HeaderOperations to domain HeaderOperations
-func convertHeaderOperations(pbOps *pb.HeadersConfig_HeaderOperations) *HeaderOperations {
+// newHeaderOperationsFromProto converts protobuf HeaderOperations to domain HeaderOperations
+func newHeaderOperationsFromProto(title HeaderOperationsType, pbOps *pb.HeadersConfig_HeaderOperations) *HeaderOperations {
 	if pbOps == nil {
 		return nil
 	}
 
 	ops := &HeaderOperations{
+		Title:         title,
 		SetHeaders:    make(map[string]string),
 		AddHeaders:    make(map[string]string),
 		RemoveHeaders: make([]string, 0),
@@ -75,10 +76,11 @@ func FromProto(pbConfig *pb.HeadersConfig) (*Headers, error) {
 		return nil, fmt.Errorf("nil headers config")
 	}
 
-	config := &Headers{
-		Request:  convertHeaderOperations(pbConfig.Request),
-		Response: convertHeaderOperations(pbConfig.Response),
-	}
+	requestOps := newHeaderOperationsFromProto(
+		RequestHeaderOperationsType, pbConfig.Request)
 
-	return config, nil
+	responseOps := newHeaderOperationsFromProto(
+		ResponseHeaderOperationsType, pbConfig.Response)
+
+	return NewHeaders(requestOps, responseOps), nil
 }

--- a/internal/config/endpoints/middleware/headers/proto_test.go
+++ b/internal/config/endpoints/middleware/headers/proto_test.go
@@ -12,7 +12,7 @@ func TestHeaders_ToProto(t *testing.T) {
 	t.Parallel()
 
 	t.Run("empty configuration", func(t *testing.T) {
-		headers := NewHeaders()
+		headers := NewHeaders(nil, nil)
 		proto := headers.ToProto()
 
 		pbConfig, ok := proto.(*pb.HeadersConfig)
@@ -295,7 +295,7 @@ func TestRoundTripConversion(t *testing.T) {
 	})
 
 	t.Run("empty configuration round trip", func(t *testing.T) {
-		original := NewHeaders()
+		original := NewHeaders(nil, nil)
 
 		proto := original.ToProto()
 		pbConfig, ok := proto.(*pb.HeadersConfig)

--- a/internal/config/endpoints/middleware/logger/console.go
+++ b/internal/config/endpoints/middleware/logger/console.go
@@ -271,7 +271,7 @@ func (c *ConsoleLogger) String() string {
 
 // ToTree returns a tree representation of the console logger
 func (c *ConsoleLogger) ToTree() *fancy.ComponentTree {
-	tree := fancy.NewComponentTree("Console Logger")
+	tree := fancy.NewComponentTree("Config:")
 
 	// General options
 	tree.AddChild(fmt.Sprintf("Format: %s", c.Options.Format))

--- a/internal/config/endpoints/middleware/middleware_test.go
+++ b/internal/config/endpoints/middleware/middleware_test.go
@@ -363,6 +363,6 @@ func TestMiddlewareCollection_ToTree(t *testing.T) {
 		assert.Contains(t, treeString, "test-logger")
 
 		// Verify config content appears in the tree
-		assert.Contains(t, treeString, "Console Logger")
+		assert.Contains(t, treeString, "Config:")
 	})
 }

--- a/internal/config/endpoints/middleware/string.go
+++ b/internal/config/endpoints/middleware/string.go
@@ -37,11 +37,16 @@ func (mc MiddlewareCollection) ToTree() *fancy.ComponentTree {
 	)
 
 	for _, middleware := range mc {
+		// Create middleware tree with ID as header (like Apps do)
 		middlewareTree := fancy.NewComponentTree(
 			fancy.MiddlewareText(middleware.ID),
 		)
 
-		// Add the middleware's own tree as a child
+		// Add Type field first with proper formatting
+		typeText := fmt.Sprintf("Type: %s", middleware.Config.Type())
+		middlewareTree.AddChild(typeText)
+
+		// Add middleware configuration using standard ToTree method
 		configTree := middleware.Config.ToTree()
 		middlewareTree.AddChild(configTree.Tree())
 

--- a/internal/server/runnables/listeners/http/middleware/headers/middleware_test.go
+++ b/internal/server/runnables/listeners/http/middleware/headers/middleware_test.go
@@ -77,7 +77,7 @@ func TestNewHeadersMiddleware(t *testing.T) {
 	})
 
 	t.Run("invalid configuration - empty", func(t *testing.T) {
-		cfg := headers.NewHeaders() // No operations configured
+		cfg := headers.NewHeaders(nil, nil) // No operations configured
 		middleware, err := NewHeadersMiddleware("test", cfg)
 		assert.Error(t, err)
 		assert.Nil(t, middleware)


### PR DESCRIPTION
before, and after:
```
❯ go run ./cmd/firelynx validate examples/config/headers.toml -t
examples/config/headers.toml: valid
Firelynx Config (v1)
├──Listeners (1)
│  ╰──http
│     ├──Address: :8080
│     ├──Type: HTTP
│     ╰──HTTP Options
│        ├──ReadTimeout: 10s
│        ├──WriteTimeout: 10s
│        ├──IdleTimeout: 1m0s
│        ╰──DrainTimeout: 30s
├──Endpoints (1)
│  ╰──main
│     ├──Listeners: http
│     ├──Middlewares (1)
│     │  ╰──header-cleanup
│     │     ╰──Headers Middleware
│     │        ├──Request Add Headers:
│     │        ├──X-Request-Source: firelynx
│     │        ├──Request Remove Headers:
│     │        ├──User-Agent
│     │        ├──Response Add Headers:
│     │        ├──X-Server: firelynx
│     │        ├──X-XSS-Protection: 1; mode=block
│     │        ├──Referrer-Policy: strict-origin-when-cross-origin
│     │        ├──X-Content-Type-Options: nosniff
│     │        ├──X-Frame-Options: DENY
│     │        ├──Response Remove Headers:
│     │        ├──Server
│     │        ╰──X-Powered-By
│     ╰──Routes (1)
│        ╰──Route 1
│           ├──App: echo
│           ╰──Condition: http_path = /
╰──Apps (1)
   ╰──echo
❯ git co rterhaar/fix-validate-output
Switched to branch 'rterhaar/fix-validate-output'
❯ go run ./cmd/firelynx validate examples/config/headers.toml -t
examples/config/headers.toml: valid
Firelynx Config (v1)
├──Listeners (1)
│  ╰──http
│     ├──Address: :8080
│     ├──Type: HTTP
│     ╰──HTTP Options
│        ├──ReadTimeout: 10s
│        ├──WriteTimeout: 10s
│        ├──IdleTimeout: 1m0s
│        ╰──DrainTimeout: 30s
├──Endpoints (1)
│  ╰──main
│     ├──Listeners: http
│     ├──Middlewares (1)
│     │  ╰──header-cleanup
│     │     ├──Type: headers
│     │     ╰──Config:
│     │        ├──Request Operations:
│     │        │  ├──Add: "X-Request-Source: firelynx"
│     │        │  ╰──Remove: "User-Agent"
│     │        ╰──Response Operations:
│     │           ├──Add: "Referrer-Policy: strict-origin-when-cross-origin"
│     │           ├──Add: "X-Content-Type-Options: nosniff"
│     │           ├──Add: "X-Frame-Options: DENY"
│     │           ├──Add: "X-Server: firelynx"
│     │           ├──Add: "X-XSS-Protection: 1; mode=block"
│     │           ├──Remove: "Server"
│     │           ╰──Remove: "X-Powered-By"
│     ╰──Routes (1)
│        ╰──Route 1
│           ├──App: echo
│           ╰──Condition: http_path = /
╰──Apps (1)
   ╰──echo
```