### PR TITLE
upgrade go-supervisor to v0.0.21

### DIFF
--- a/cmd/firelynx/validate_test.go
+++ b/cmd/firelynx/validate_test.go
@@ -123,14 +123,14 @@ func TestValidateRemote(t *testing.T) {
 
 	// Wait for server to start
 	require.Eventually(t, func() bool {
-		return cfgServiceRunner.IsRunning()
+		return cfgServiceRunner.IsReady()
 	}, time.Second, 10*time.Millisecond, "gRPC config service should start")
 
 	// Cleanup function
 	defer func() {
 		cfgServiceRunner.Stop()
 		assert.Eventually(t, func() bool {
-			return !cfgServiceRunner.IsRunning()
+			return !cfgServiceRunner.IsReady()
 		}, time.Second, 10*time.Millisecond, "gRPC config service should stop")
 	}()
 
@@ -360,7 +360,7 @@ func TestValidateRemoteShutdownTiming(t *testing.T) {
 
 			// Wait for server to start
 			require.Eventually(t, func() bool {
-				return cfgServiceRunner.IsRunning()
+				return cfgServiceRunner.IsReady()
 			}, time.Second, 10*time.Millisecond, "gRPC config service should start")
 
 			configPath := createTempConfigFile(t, validConfigContent)
@@ -385,7 +385,7 @@ func TestValidateRemoteShutdownTiming(t *testing.T) {
 
 			// Verify shutdown completes quickly using assert.Eventually
 			assert.Eventually(func() bool {
-				return !cfgServiceRunner.IsRunning()
+				return !cfgServiceRunner.IsReady()
 			}, 2*time.Second, 10*time.Millisecond, "gRPC config service should stop")
 
 			// Check for any unexpected server errors (with timeout)

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/robbyt/go-fsm/v2 v2.3.0
 	github.com/robbyt/go-loglater v0.2.0
 	github.com/robbyt/go-polyscript v0.6.0
-	github.com/robbyt/go-supervisor v0.0.19
+	github.com/robbyt/go-supervisor v0.0.21
 	github.com/robbyt/mcp-io v0.0.1
 	github.com/robbyt/protobaggins v0.2.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/robbyt/go-loglater v0.2.0 h1:9ci8njlgoiqqx+zfpr3F8uOBeORLSDDY+u+L0frC
 github.com/robbyt/go-loglater v0.2.0/go.mod h1:JTuKjCRdC6dsOs3k70zgJVkZVk+OT4cCsgUfw15B6dk=
 github.com/robbyt/go-polyscript v0.6.0 h1:bZCUiR3gxzOgLG3WuP48iLuoddl4bMp8JgFYpjs8AfE=
 github.com/robbyt/go-polyscript v0.6.0/go.mod h1:TCTYLks48MdjeMloQtQL2t2odH9IkjDLWQXUfhNN80I=
-github.com/robbyt/go-supervisor v0.0.19 h1:INFW1zJlHdIO57jVewo5IRJJfmJ1Tcqy92Mbhz6fcR8=
-github.com/robbyt/go-supervisor v0.0.19/go.mod h1:vTPXrw5qmDubSPsvyZMi2i7GJG80lkMPW4cWkmuqm4Y=
+github.com/robbyt/go-supervisor v0.0.21 h1:EnfkcbS3vrJwgNg//4MmwWpuHSeqdUTa1OlkcjxMaUk=
+github.com/robbyt/go-supervisor v0.0.21/go.mod h1:TSmuA1z2zwlq6esWMjAxy5/VXuWAmR/4bYBOz9sQasg=
 github.com/robbyt/mcp-io v0.0.1 h1:4c5mP6GiM1xtFiUztg6GqC0dx/HdQK4KLMZnAc38JC0=
 github.com/robbyt/mcp-io v0.0.1/go.mod h1:Mj4NIozkg6DfyRlgduknsKZr8LL/siy3phLeFDW8MxY=
 github.com/robbyt/protobaggins v0.2.0 h1:M5XaeEAXTrp9Jke6jpmy4HJAw3lhtVNflDKdWErkXUM=

--- a/internal/server/integration_tests/configupdates/channels_test.go
+++ b/internal/server/integration_tests/configupdates/channels_test.go
@@ -92,7 +92,7 @@ func TestConfigChannels_BasicFlow(t *testing.T) {
 
 	// Wait for txmgr to be ready
 	assert.Eventually(t, func() bool {
-		return h.txmgr.IsRunning()
+		return h.txmgr.IsReady()
 	}, 2*time.Second, 10*time.Millisecond)
 
 	// Create cfgservice runner with siphon
@@ -104,7 +104,7 @@ func TestConfigChannels_BasicFlow(t *testing.T) {
 
 	// Wait for cfgservice runner to be ready
 	assert.Eventually(t, func() bool {
-		return cfgServiceRunner.IsRunning()
+		return cfgServiceRunner.IsReady()
 	}, 2*time.Second, 10*time.Millisecond)
 
 	// Test a simple config update to verify the flow works
@@ -144,7 +144,7 @@ func TestConfigChannels_CfgFileLoaderIntegration(t *testing.T) {
 
 	// Wait for txmgr to be ready
 	assert.Eventually(t, func() bool {
-		return h.txmgr.IsRunning()
+		return h.txmgr.IsReady()
 	}, 2*time.Second, 10*time.Millisecond)
 
 	// Create temporary config file
@@ -167,7 +167,7 @@ func TestConfigChannels_CfgFileLoaderIntegration(t *testing.T) {
 
 	// Wait for runner to reach running state and process initial config
 	assert.Eventually(t, func() bool {
-		return fileLoader.IsRunning()
+		return fileLoader.IsReady()
 	}, 2*time.Second, 10*time.Millisecond)
 
 	// Update config file to trigger reload
@@ -175,11 +175,11 @@ func TestConfigChannels_CfgFileLoaderIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Trigger reload
-	fileLoader.Reload()
+	require.NoError(t, fileLoader.Reload(h.ctx))
 
 	// Verify config was updated (simple check that reload worked)
 	assert.Eventually(t, func() bool {
-		return fileLoader.IsRunning() // Still running after reload
+		return fileLoader.IsReady() // Still running after reload
 	}, 1*time.Second, 10*time.Millisecond)
 }
 
@@ -196,7 +196,7 @@ func TestConfigChannels_MultipleUpdates(t *testing.T) {
 
 	// Wait for txmgr to be ready
 	assert.Eventually(t, func() bool {
-		return h.txmgr.IsRunning()
+		return h.txmgr.IsReady()
 	}, 2*time.Second, 10*time.Millisecond)
 
 	// Create cfgservice runner with siphon
@@ -208,7 +208,7 @@ func TestConfigChannels_MultipleUpdates(t *testing.T) {
 
 	// Wait for cfgservice runner to be ready
 	assert.Eventually(t, func() bool {
-		return cfgServiceRunner.IsRunning()
+		return cfgServiceRunner.IsReady()
 	}, 2*time.Second, 10*time.Millisecond)
 
 	// Test multiple sequential config updates

--- a/internal/server/integration_tests/configupdates/grpc_config_test.go
+++ b/internal/server/integration_tests/configupdates/grpc_config_test.go
@@ -165,11 +165,11 @@ func TestGRPCConfigServiceHTTPIntegration(t *testing.T) {
 
 	// Wait for both runners to start
 	require.Eventually(t, func() bool {
-		return httpRunner.IsRunning()
+		return httpRunner.IsReady()
 	}, time.Second, 10*time.Millisecond, "HTTP runner should start")
 
 	require.Eventually(t, func() bool {
-		return cfgServiceRunner.IsRunning()
+		return cfgServiceRunner.IsReady()
 	}, time.Second, 10*time.Millisecond, "gRPC config service should start")
 
 	// Process transactions from siphon
@@ -403,11 +403,11 @@ func TestGRPCConfigServiceHTTPIntegration(t *testing.T) {
 	httpRunner.Stop()
 
 	assert.Eventually(t, func() bool {
-		return !cfgServiceRunner.IsRunning()
+		return !cfgServiceRunner.IsReady()
 	}, time.Second, 10*time.Millisecond, "gRPC config service should stop")
 
 	assert.Eventually(t, func() bool {
-		return !httpRunner.IsRunning()
+		return !httpRunner.IsReady()
 	}, time.Second, 10*time.Millisecond, "HTTP runner should stop")
 }
 
@@ -432,7 +432,7 @@ func TestValidateConfigIntegration(t *testing.T) {
 
 	// Wait for config service to start
 	require.Eventually(t, func() bool {
-		return cfgServiceRunner.IsRunning()
+		return cfgServiceRunner.IsReady()
 	}, time.Second, 10*time.Millisecond, "gRPC config service should start")
 
 	// Create client
@@ -496,6 +496,6 @@ func TestValidateConfigIntegration(t *testing.T) {
 	cfgServiceRunner.Stop()
 
 	assert.Eventually(t, func() bool {
-		return !cfgServiceRunner.IsRunning()
+		return !cfgServiceRunner.IsReady()
 	}, time.Second, 10*time.Millisecond, "gRPC config service should stop")
 }

--- a/internal/server/integration_tests/configupdates/saga_timing_test.go
+++ b/internal/server/integration_tests/configupdates/saga_timing_test.go
@@ -85,11 +85,11 @@ func TestSagaTimingVsHTTPServerReadiness(t *testing.T) {
 
 	// Wait for both runners to start
 	require.Eventually(t, func() bool {
-		return httpRunner.IsRunning()
+		return httpRunner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 
 	require.Eventually(t, func() bool {
-		return cfgServiceRunner.IsRunning()
+		return cfgServiceRunner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 
 	// Process transactions from siphon
@@ -175,7 +175,7 @@ func TestHTTPRunnerRequiresInitialConfig(t *testing.T) {
 
 	// Wait for txmgr to be running
 	require.Eventually(t, func() bool {
-		return txMan.IsRunning()
+		return txMan.IsReady()
 	}, time.Second, 10*time.Millisecond, "txmgr should start and be ready to process transactions")
 
 	// Start the HTTP runner

--- a/internal/server/integration_tests/configupdates/supervisor_startup_test.go
+++ b/internal/server/integration_tests/configupdates/supervisor_startup_test.go
@@ -193,7 +193,7 @@ func TestHTTPRunnerStartupTiming(t *testing.T) {
 
 	// Wait for txmgr to be running
 	require.Eventually(t, func() bool {
-		return txMan.IsRunning()
+		return txMan.IsReady()
 	}, 2*time.Second, 50*time.Millisecond, "Transaction manager should be running")
 
 	// HTTP runner should be Running immediately

--- a/internal/server/integration_tests/configupdates/validate_shutdown_test.go
+++ b/internal/server/integration_tests/configupdates/validate_shutdown_test.go
@@ -42,7 +42,7 @@ func TestValidateConfigShutdownTimeout(t *testing.T) {
 
 	// Wait for config service to start
 	require.Eventually(t, func() bool {
-		return cfgServiceRunner.IsRunning()
+		return cfgServiceRunner.IsReady()
 	}, time.Second, 10*time.Millisecond, "gRPC config service should start")
 
 	// Create client
@@ -93,7 +93,7 @@ func TestValidateConfigShutdownTimeout(t *testing.T) {
 	shutdownComplete := make(chan bool, 1)
 	go func() {
 		assert.Eventually(t, func() bool {
-			return !cfgServiceRunner.IsRunning()
+			return !cfgServiceRunner.IsReady()
 		}, 3*time.Second, 10*time.Millisecond, "gRPC config service should stop")
 		shutdownComplete <- true
 	}()
@@ -148,7 +148,7 @@ func TestValidateConfigMultipleCallsShutdown(t *testing.T) {
 
 	// Wait for config service to start
 	require.Eventually(t, func() bool {
-		return cfgServiceRunner.IsRunning()
+		return cfgServiceRunner.IsReady()
 	}, time.Second, 10*time.Millisecond, "gRPC config service should start")
 
 	// Create client
@@ -196,7 +196,7 @@ func TestValidateConfigMultipleCallsShutdown(t *testing.T) {
 	shutdownComplete := make(chan bool, 1)
 	go func() {
 		assert.Eventually(t, func() bool {
-			return !cfgServiceRunner.IsRunning()
+			return !cfgServiceRunner.IsReady()
 		}, 3*time.Second, 10*time.Millisecond, "gRPC config service should stop")
 		shutdownComplete <- true
 	}()

--- a/internal/server/integration_tests/http/headers_integration_test.go
+++ b/internal/server/integration_tests/http/headers_integration_test.go
@@ -86,7 +86,7 @@ func (s *HeadersIntegrationTestSuite) SetupSuite() {
 			s.T().Fatalf("HTTP runner failed to start: %v", err)
 			return false
 		default:
-			return s.httpRunner.IsRunning()
+			return s.httpRunner.IsReady()
 		}
 	}, time.Second, 10*time.Millisecond, "HTTP runner should start")
 
@@ -120,7 +120,7 @@ func (s *HeadersIntegrationTestSuite) TearDownSuite() {
 		s.httpRunner.Stop()
 
 		s.Require().Eventually(func() bool {
-			return !s.httpRunner.IsRunning()
+			return !s.httpRunner.IsReady()
 		}, time.Second, 10*time.Millisecond, "HTTP runner should stop")
 
 		select {

--- a/internal/server/integration_tests/http/http_minimal_test.go
+++ b/internal/server/integration_tests/http/http_minimal_test.go
@@ -43,7 +43,7 @@ func TestHTTPListenerMinimalSaga(t *testing.T) {
 
 	// Wait for runner to start
 	assert.Eventually(t, func() bool {
-		return httpRunner.IsRunning()
+		return httpRunner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 
 	// Create a minimal configuration using string
@@ -71,7 +71,7 @@ func TestHTTPListenerMinimalSaga(t *testing.T) {
 
 	// Wait a moment for the runner state to stabilize
 	assert.Eventually(t, func() bool {
-		return httpRunner.IsRunning()
+		return httpRunner.IsReady()
 	}, 100*time.Millisecond, 10*time.Millisecond, "HTTP runner should be running after transaction completes")
 
 	// Stop the HTTP runner
@@ -79,7 +79,7 @@ func TestHTTPListenerMinimalSaga(t *testing.T) {
 
 	// Wait for runner to stop
 	assert.Eventually(t, func() bool {
-		return !httpRunner.IsRunning()
+		return !httpRunner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 
 	// Check for any unexpected runner errors (with timeout)
@@ -119,7 +119,7 @@ func TestHTTPListenerConfigUpdate(t *testing.T) {
 
 	// Wait for runner to start
 	assert.Eventually(t, func() bool {
-		return httpRunner.IsRunning()
+		return httpRunner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 
 	// First configuration - empty
@@ -159,7 +159,7 @@ address = "127.0.0.1:0"
 
 	// Verify runner is still running
 	assert.Eventually(t, func() bool {
-		return httpRunner.IsRunning()
+		return httpRunner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 
 	// Stop the HTTP runner
@@ -167,6 +167,6 @@ address = "127.0.0.1:0"
 
 	// Wait for runner to stop
 	assert.Eventually(t, func() bool {
-		return !httpRunner.IsRunning()
+		return !httpRunner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 }

--- a/internal/server/integration_tests/http/httpcluster_test.go
+++ b/internal/server/integration_tests/http/httpcluster_test.go
@@ -177,7 +177,7 @@ func TestHTTPClusterDynamicListeners(t *testing.T) {
 
 	// Wait for runner to start
 	require.Eventually(t, func() bool {
-		return httpRunner.IsRunning()
+		return httpRunner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 
 	// Test 1: Start with no listeners
@@ -252,7 +252,7 @@ func TestHTTPClusterDynamicListeners(t *testing.T) {
 	// Stop the HTTP runner
 	httpRunner.Stop()
 	assert.Eventually(t, func() bool {
-		return !httpRunner.IsRunning()
+		return !httpRunner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 }
 
@@ -280,7 +280,7 @@ func TestHTTPClusterWithRoutesAndApps(t *testing.T) {
 
 	// Wait for runner to start
 	require.Eventually(t, func() bool {
-		return httpRunner.IsRunning()
+		return httpRunner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 
 	// Create configuration with listener, endpoint, route and app
@@ -329,7 +329,7 @@ func TestHTTPClusterWithRoutesAndApps(t *testing.T) {
 	// Stop the HTTP runner
 	httpRunner.Stop()
 	assert.Eventually(t, func() bool {
-		return !httpRunner.IsRunning()
+		return !httpRunner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 }
 
@@ -360,7 +360,7 @@ func TestHTTPClusterRouteUpdates(t *testing.T) {
 
 	// Wait for runner to start
 	require.Eventually(t, func() bool {
-		return httpRunner.IsRunning()
+		return httpRunner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 
 	port := fmt.Sprintf("%d", testutil.GetRandomPort(t))
@@ -469,7 +469,7 @@ func TestHTTPClusterRouteUpdates(t *testing.T) {
 	// Stop the HTTP runner
 	httpRunner.Stop()
 	assert.Eventually(t, func() bool {
-		return !httpRunner.IsRunning()
+		return !httpRunner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 }
 
@@ -498,7 +498,7 @@ func TestHTTPClusterErrorHandling(t *testing.T) {
 
 	// Wait for runner to start
 	require.Eventually(t, func() bool {
-		return httpRunner.IsRunning()
+		return httpRunner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 
 	// Get a random port for testing
@@ -554,7 +554,7 @@ func TestHTTPClusterErrorHandling(t *testing.T) {
 		// Stop the HTTP runner
 		httpRunner.Stop()
 		assert.Eventually(t, func() bool {
-			return !httpRunner.IsRunning()
+			return !httpRunner.IsReady()
 		}, time.Second, 10*time.Millisecond)
 	})
 }
@@ -590,7 +590,7 @@ func TestHTTPClusterSagaCompensation(t *testing.T) {
 
 	// Wait for runner to start
 	require.Eventually(t, func() bool {
-		return httpRunner.IsRunning()
+		return httpRunner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 
 	// Create configuration
@@ -620,7 +620,7 @@ func TestHTTPClusterSagaCompensation(t *testing.T) {
 	// Stop the HTTP runner
 	httpRunner.Stop()
 	assert.Eventually(t, func() bool {
-		return !httpRunner.IsRunning()
+		return !httpRunner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 }
 
@@ -644,7 +644,7 @@ func (m *MockFailingParticipant) GetState() string {
 	return "running"
 }
 
-func (m *MockFailingParticipant) IsRunning() bool {
+func (m *MockFailingParticipant) IsReady() bool {
 	return true
 }
 

--- a/internal/server/integration_tests/http/logger_integration_test.go
+++ b/internal/server/integration_tests/http/logger_integration_test.go
@@ -204,7 +204,7 @@ func (s *LoggerIntegrationTestSuite) SetupSuite() {
 			s.T().Fatalf("HTTP runner failed to start: %v", err)
 			return false
 		default:
-			return s.httpRunner.IsRunning()
+			return s.httpRunner.IsReady()
 		}
 	}, time.Second, 10*time.Millisecond, "HTTP runner should start")
 
@@ -246,7 +246,7 @@ func (s *LoggerIntegrationTestSuite) TearDownSuite() {
 
 		// Wait for runner to stop
 		s.Require().Eventually(func() bool {
-			return !s.httpRunner.IsRunning()
+			return !s.httpRunner.IsReady()
 		}, time.Second, 10*time.Millisecond, "HTTP runner should stop")
 
 		// Wait for background goroutine to complete

--- a/internal/server/integration_tests/http/script_integration_test.go
+++ b/internal/server/integration_tests/http/script_integration_test.go
@@ -147,7 +147,7 @@ func setupScriptSuiteWithEndpoint(t *testing.T, templateName, templateContent st
 			t.Fatalf("HTTP runner failed to start: %v", err)
 			return false
 		default:
-			return fields.httpRunner.IsRunning()
+			return fields.httpRunner.IsReady()
 		}
 	}, time.Second, 10*time.Millisecond, "HTTP runner should start")
 
@@ -240,7 +240,7 @@ func setupScriptSuiteWithFile(t *testing.T, templateName, templateContent, scrip
 			t.Fatalf("HTTP runner failed to start: %v", err)
 			return false
 		default:
-			return fields.httpRunner.IsRunning()
+			return fields.httpRunner.IsReady()
 		}
 	}, time.Second, 10*time.Millisecond, "HTTP runner should start")
 
@@ -334,7 +334,7 @@ func setupScriptSuiteWithHTTPS(t *testing.T, templateName, templateContent, scri
 			t.Fatalf("HTTP runner failed to start: %v", err)
 			return false
 		default:
-			return fields.httpRunner.IsRunning()
+			return fields.httpRunner.IsReady()
 		}
 	}, time.Second, 10*time.Millisecond, "HTTP runner should start")
 
@@ -383,7 +383,7 @@ func teardownScriptSuite(t *testing.T, fields *scriptSuiteFields) {
 
 		// Wait for runner to stop
 		require.Eventually(t, func() bool {
-			return !fields.httpRunner.IsRunning()
+			return !fields.httpRunner.IsReady()
 		}, time.Second, 10*time.Millisecond, "HTTP runner should stop")
 	}
 }
@@ -756,7 +756,7 @@ _ = result`
 			s.T().Fatalf("HTTP runner failed to start: %v", err)
 			return false
 		default:
-			return s.httpRunner.IsRunning()
+			return s.httpRunner.IsReady()
 		}
 	}, time.Second, 10*time.Millisecond, "HTTP runner should start")
 
@@ -798,7 +798,7 @@ func (s *StarlarkFileURIIntegrationTestSuite) TearDownSuite() {
 
 		// Wait for runner to stop
 		s.Require().Eventually(func() bool {
-			return !s.httpRunner.IsRunning()
+			return !s.httpRunner.IsReady()
 		}, time.Second, 10*time.Millisecond, "HTTP runner should stop")
 	}
 }
@@ -912,7 +912,7 @@ func (s *ExtismIntegrationTestSuite) SetupSuite() {
 			s.T().Fatalf("HTTP runner failed to start: %v", err)
 			return false
 		default:
-			return s.httpRunner.IsRunning()
+			return s.httpRunner.IsReady()
 		}
 	}, time.Second, 10*time.Millisecond, "HTTP runner should start")
 
@@ -954,7 +954,7 @@ func (s *ExtismIntegrationTestSuite) TearDownSuite() {
 
 		// Wait for runner to stop
 		s.Require().Eventually(func() bool {
-			return !s.httpRunner.IsRunning()
+			return !s.httpRunner.IsReady()
 		}, time.Second, 10*time.Millisecond, "HTTP runner should stop")
 	}
 }

--- a/internal/server/integration_tests/http/single_logger_debug_test.go
+++ b/internal/server/integration_tests/http/single_logger_debug_test.go
@@ -72,7 +72,7 @@ func TestSingleLoggerFileOutput(t *testing.T) {
 	}()
 
 	require.Eventually(t, func() bool {
-		return httpRunner.IsRunning()
+		return httpRunner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 
 	tx, err := transaction.FromTest(t.Name(), cfg, nil)
@@ -106,6 +106,6 @@ func TestSingleLoggerFileOutput(t *testing.T) {
 
 	httpRunner.Stop()
 	require.Eventually(t, func() bool {
-		return !httpRunner.IsRunning()
+		return !httpRunner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 }

--- a/internal/server/integration_tests/http/static_data_integration_test.go
+++ b/internal/server/integration_tests/http/static_data_integration_test.go
@@ -100,7 +100,7 @@ func (s *StaticDataIntegrationSuite) SetupSuite() {
 			s.T().Fatalf("HTTP runner failed to start: %v", err)
 			return false
 		default:
-			return s.httpRunner.IsRunning()
+			return s.httpRunner.IsReady()
 		}
 	}, time.Second, 10*time.Millisecond, "HTTP runner should start")
 

--- a/internal/server/integration_tests/mcp/base_suite.go
+++ b/internal/server/integration_tests/mcp/base_suite.go
@@ -87,7 +87,7 @@ func (s *MCPIntegrationTestSuite) startServerWithConfig(cfg *config.Config) {
 			s.T().Fatalf("HTTP runner failed to start: %v", err)
 			return false
 		default:
-			return s.httpRunner.IsRunning()
+			return s.httpRunner.IsReady()
 		}
 	}, time.Second, 10*time.Millisecond, "HTTP runner should start")
 
@@ -206,7 +206,7 @@ func (s *MCPIntegrationTestSuite) TearDownSuite() {
 
 		// Wait for runner to stop
 		s.Require().Eventually(func() bool {
-			return !s.httpRunner.IsRunning()
+			return !s.httpRunner.IsReady()
 		}, time.Second, 10*time.Millisecond, "HTTP runner should stop")
 	}
 }

--- a/internal/server/runnables/cfgfileloader/runner.go
+++ b/internal/server/runnables/cfgfileloader/runner.go
@@ -219,6 +219,8 @@ func (r *Runner) Reload(ctx context.Context) error {
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
+	case <-r.ctx.Done():
+		return r.ctx.Err()
 	}
 }
 

--- a/internal/server/runnables/cfgfileloader/runner.go
+++ b/internal/server/runnables/cfgfileloader/runner.go
@@ -199,9 +199,6 @@ func (r *Runner) Reload(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
 	}
-	if newCfg == nil {
-		return errors.New("no config loaded")
-	}
 
 	oldCfg := r.getConfig()
 	if oldCfg != nil && oldCfg.Equals(newCfg) {
@@ -212,9 +209,6 @@ func (r *Runner) Reload(ctx context.Context) error {
 	tx, err := r.validate(newCfg)
 	if err != nil {
 		return fmt.Errorf("validating config: %w", err)
-	}
-	if tx == nil {
-		return errors.New("no valid transaction created")
 	}
 
 	r.lastValidTransaction.Store(tx)

--- a/internal/server/runnables/cfgfileloader/runner.go
+++ b/internal/server/runnables/cfgfileloader/runner.go
@@ -17,6 +17,7 @@ var (
 	_ supervisor.Runnable   = (*Runner)(nil)
 	_ supervisor.Reloadable = (*Runner)(nil)
 	_ supervisor.Stateable  = (*Runner)(nil)
+	_ supervisor.Readiness  = (*Runner)(nil)
 )
 
 type Runner struct {
@@ -185,47 +186,35 @@ func (r *Runner) shutdown() error {
 }
 
 // Reload implements the supervisor.Reloadable interface
-func (r *Runner) Reload() {
+func (r *Runner) Reload(ctx context.Context) error {
 	r.logger.Debug("Starting Reload...")
-	defer func() {
-		r.logger.Debug("Reload completed")
-	}()
+	defer r.logger.Debug("Reload completed")
 
 	if r.filePath == "" {
 		r.logger.Warn("No config path set, skipping reload")
-		return
+		return nil
 	}
 
 	newCfg, err := r.loadConfigFromDisk()
 	if err != nil {
-		r.logger.Error("Failed to reload config", "error", err)
-		return
+		return fmt.Errorf("loading config: %w", err)
 	}
-
 	if newCfg == nil {
-		r.logger.Error("No config loaded, skipping reload")
-		return
+		return errors.New("no config loaded")
 	}
 
-	// Only broadcast if config has changed
-	reloadNeeded := true
 	oldCfg := r.getConfig()
-	if oldCfg != nil {
-		reloadNeeded = !oldCfg.Equals(newCfg)
-	}
-	if !reloadNeeded {
+	if oldCfg != nil && oldCfg.Equals(newCfg) {
 		r.logger.Debug("Config unchanged, skipping broadcast")
-		return
+		return nil
 	}
 
 	tx, err := r.validate(newCfg)
 	if err != nil {
-		r.logger.Error("Failed to validate config", "error", err)
-		return
+		return fmt.Errorf("validating config: %w", err)
 	}
 	if tx == nil {
-		r.logger.Error("No valid transaction created, skipping broadcast")
-		return
+		return errors.New("no valid transaction created")
 	}
 
 	r.lastValidTransaction.Store(tx)
@@ -233,8 +222,9 @@ func (r *Runner) Reload() {
 	select {
 	case r.txSiphon <- tx:
 		r.logger.Debug("Config changed, transaction sent to siphon", "id", tx.ID)
-	case <-r.ctx.Done():
-		r.logger.Debug("Context cancelled while sending transaction")
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/internal/server/runnables/cfgfileloader/runner_test.go
+++ b/internal/server/runnables/cfgfileloader/runner_test.go
@@ -265,8 +265,61 @@ func TestRunner_Reload(t *testing.T) {
 
 		h := newTestHarness(t, configPath)
 
-		require.Error(t, h.runner.Reload(h.ctx))
+		err = h.runner.Reload(h.ctx)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "loading config:")
 		assert.Nil(t, h.runner.getConfig())
+	})
+
+	t.Run("reload with validation failure returns wrapped error", func(t *testing.T) {
+		// TOML parses fine, but the route references an app that does not exist —
+		// validation rejects it.
+		const badConfig = `
+version = "v1"
+
+[[listeners]]
+id = "test"
+address = ":8080"
+type = "http"
+
+[[endpoints]]
+id = "test-endpoint"
+listener_id = "test"
+
+[[endpoints.routes]]
+app_id = "missing-app"
+[endpoints.routes.http]
+path_prefix = "/test"
+`
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "validation_fails.toml")
+		require.NoError(t, os.WriteFile(configPath, []byte(badConfig), 0o644))
+
+		h := newTestHarness(t, configPath)
+
+		err := h.runner.Reload(h.ctx)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "validating config:")
+		assert.Nil(t, h.runner.getConfig())
+	})
+
+	t.Run("reload returns ctx.Err when context cancelled before send", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "valid_for_ctx_test.toml")
+		require.NoError(t, os.WriteFile(configPath, validConfigTOML, 0o644))
+
+		// Unbuffered siphon with no consumer + already-cancelled ctx forces
+		// the select to take the <-ctx.Done() branch.
+		txSiphon := make(chan *transaction.ConfigTransaction)
+		runner, err := NewRunner(configPath, txSiphon)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		err = runner.Reload(ctx)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
 	})
 
 	t.Run("reload while running sends transactions", func(t *testing.T) {

--- a/internal/server/runnables/cfgfileloader/runner_test.go
+++ b/internal/server/runnables/cfgfileloader/runner_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/atlanticdynamic/firelynx/internal/config/transaction"
@@ -622,4 +623,46 @@ func TestRunner_ConcurrentAccess(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("Runner did not complete within timeout")
 	}
+}
+
+// TestRunner_Reload_ReturnsWhenRctxCanceledButCallerCtxAlive regression test:
+// the v0.0.21 supervisor migration changed Reload's siphon-send select to only
+// observe the caller-supplied ctx, dropping the previous r.ctx.Done() case. If
+// the runner has been Stopped (r.ctx canceled) but the caller passes an
+// independent live ctx, the unbuffered siphon send blocks forever when no
+// receiver is present. Reload must fall through to r.ctx and return.
+func TestRunner_Reload_ReturnsWhenRctxCanceledButCallerCtxAlive(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "valid.toml")
+		require.NoError(t, os.WriteFile(configPath, validConfigTOML, 0o644))
+
+		// Unbuffered siphon with no consumer — the send must block.
+		txSiphon := make(chan *transaction.ConfigTransaction)
+		runner, err := NewRunner(configPath, txSiphon)
+		require.NoError(t, err)
+
+		// Simulate post-Stop state directly: r.ctx canceled, caller ctx independent and alive.
+		canceledCtx, cancelRctx := context.WithCancel(context.Background())
+		cancelRctx()
+		runner.ctx = canceledCtx
+
+		callerCtx := context.Background()
+		reloadDone := make(chan error, 1)
+		go func() { reloadDone <- runner.Reload(callerCtx) }()
+
+		// synctest.Wait returns only when every goroutine in the bubble is
+		// durably blocked. Without the r.ctx case, the Reload goroutine sits
+		// on the siphon send forever; with it, Reload returns and reloadDone
+		// is filled before this point.
+		synctest.Wait()
+
+		select {
+		case err := <-reloadDone:
+			require.Error(t, err)
+			require.ErrorIs(t, err, context.Canceled)
+		default:
+			t.Fatal("Reload hangs when r.ctx is canceled but caller ctx is alive")
+		}
+	})
 }

--- a/internal/server/runnables/cfgfileloader/runner_test.go
+++ b/internal/server/runnables/cfgfileloader/runner_test.go
@@ -226,7 +226,7 @@ func TestRunner_Reload(t *testing.T) {
 	t.Run("reload with default config", func(t *testing.T) {
 		h := newTestHarness(t, "")
 
-		h.runner.Reload()
+		require.NoError(t, h.runner.Reload(h.ctx))
 		// Now that we create a valid config file by default, it should load successfully
 		assert.NotNil(t, h.runner.getConfig())
 	})
@@ -242,7 +242,7 @@ func TestRunner_Reload(t *testing.T) {
 		assert.Nil(t, h.runner.getConfig())
 
 		// Reload when not running - config should be stored but no transaction sent
-		h.runner.Reload()
+		require.NoError(t, h.runner.Reload(h.ctx))
 		cfg := h.runner.getConfig()
 		assert.NotNil(t, cfg)
 
@@ -251,13 +251,13 @@ func TestRunner_Reload(t *testing.T) {
 		require.NoError(t, err)
 
 		// Reload again - config should be updated but still no transaction
-		h.runner.Reload()
+		require.NoError(t, h.runner.Reload(h.ctx))
 		newCfg := h.runner.getConfig()
 		assert.NotNil(t, newCfg)
 		assert.NotSame(t, cfg, newCfg)
 	})
 
-	t.Run("reload with invalid config file logs error", func(t *testing.T) {
+	t.Run("reload with invalid config file returns error", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configPath := filepath.Join(tmpDir, "invalid_config.toml")
 		err := os.WriteFile(configPath, invalidConfigTOML, 0o644)
@@ -265,7 +265,7 @@ func TestRunner_Reload(t *testing.T) {
 
 		h := newTestHarness(t, configPath)
 
-		h.runner.Reload()
+		require.Error(t, h.runner.Reload(h.ctx))
 		assert.Nil(t, h.runner.getConfig())
 	})
 
@@ -295,7 +295,7 @@ func TestRunner_Reload(t *testing.T) {
 		err = os.WriteFile(configPath, updatedConfigTOML, 0o644)
 		require.NoError(t, err)
 
-		h.runner.Reload()
+		require.NoError(t, h.runner.Reload(h.ctx))
 		tx2 := h.receiveTransaction()
 		assert.NotNil(t, tx2)
 
@@ -329,7 +329,7 @@ func TestRunner_GetConfig(t *testing.T) {
 
 		h := newTestHarness(t, configPath)
 
-		h.runner.Reload()
+		require.NoError(t, h.runner.Reload(h.ctx))
 		cfg := h.runner.getConfig()
 		assert.NotNil(t, cfg)
 		// No transaction expected when not running
@@ -350,7 +350,7 @@ func TestRunner_StateInterfaces(t *testing.T) {
 		stateCh := h.runner.GetStateChan(ctx)
 		assert.NotNil(t, stateCh)
 
-		assert.False(t, h.runner.IsRunning())
+		assert.False(t, h.runner.IsReady())
 	})
 
 	t.Run("state changes during lifecycle", func(t *testing.T) {
@@ -394,7 +394,7 @@ func TestRunner_StateInterfaces(t *testing.T) {
 		}
 
 		// Verify runner is now running
-		assert.True(t, h.runner.IsRunning())
+		assert.True(t, h.runner.IsReady())
 
 		// Trigger shutdown
 		runCancel()
@@ -425,7 +425,7 @@ func TestRunner_StateInterfaces(t *testing.T) {
 
 		// Final verification
 		assert.Equal(t, finitestate.StatusStopped, h.runner.GetState())
-		assert.False(t, h.runner.IsRunning())
+		assert.False(t, h.runner.IsReady())
 	})
 }
 
@@ -447,7 +447,7 @@ func TestRunner_Shutdown(t *testing.T) {
 		require.NoError(t, err)
 
 		// Load a config to verify it gets cleared
-		h.runner.Reload()
+		require.NoError(t, h.runner.Reload(h.ctx))
 		assert.NotNil(t, h.runner.getConfig())
 
 		// Call shutdown directly
@@ -497,7 +497,7 @@ func TestRunner_Shutdown(t *testing.T) {
 		assert.Equal(t, finitestate.StatusNew, h.runner.GetState())
 
 		// Load a config to verify it gets cleared even when FSM transition fails
-		h.runner.Reload()
+		require.NoError(t, h.runner.Reload(h.ctx))
 		assert.NotNil(t, h.runner.getConfig())
 
 		// Call shutdown from New state - this will fail FSM transitions but should still clear config
@@ -541,8 +541,8 @@ func TestRunner_ConcurrentAccess(t *testing.T) {
 	for range 10 {
 		go func() {
 			defer func() { done <- true }()
-			for j := 0; j < 100; j++ {
-				h.runner.Reload()
+			for range 100 {
+				_ = h.runner.Reload(h.ctx) //nolint:errcheck // concurrent-access stress test, per-call error not meaningful
 				cfg := h.runner.getConfig()
 				if cfg != nil {
 					_ = cfg.String()

--- a/internal/server/runnables/cfgfileloader/state.go
+++ b/internal/server/runnables/cfgfileloader/state.go
@@ -17,6 +17,6 @@ func (r *Runner) GetStateChan(ctx context.Context) <-chan string {
 	return r.fsm.GetStateChan(ctx)
 }
 
-func (r *Runner) IsRunning() bool {
+func (r *Runner) IsReady() bool {
 	return r.fsm.GetState() == finitestate.StatusRunning
 }

--- a/internal/server/runnables/cfgservice/runner_test.go
+++ b/internal/server/runnables/cfgservice/runner_test.go
@@ -153,7 +153,7 @@ func TestStop(t *testing.T) {
 
 		// Wait for the server to start (it will transition to Running state)
 		require.Eventually(t, func() bool {
-			return r.IsRunning()
+			return r.IsReady()
 		}, 1*time.Second, 10*time.Millisecond, "Server should reach Running state")
 
 		// Now replace the gRPC server with a mock to test GracefulStop

--- a/internal/server/runnables/cfgservice/state.go
+++ b/internal/server/runnables/cfgservice/state.go
@@ -6,8 +6,8 @@ import (
 	"github.com/atlanticdynamic/firelynx/internal/server/finitestate"
 )
 
-// IsRunning returns true if the runner is in the Running state
-func (r *Runner) IsRunning() bool {
+// IsReady returns true if the runner is in the Running state
+func (r *Runner) IsReady() bool {
 	return r.fsm.GetState() == finitestate.StatusRunning
 }
 

--- a/internal/server/runnables/cfgservice/state_test.go
+++ b/internal/server/runnables/cfgservice/state_test.go
@@ -72,7 +72,7 @@ func TestRunner_IsRunning(t *testing.T) {
 		h := newRunnerTestHarness(t, testutil.GetRandomListeningPort(t))
 		r := h.runner
 
-		assert.False(t, r.IsRunning())
+		assert.False(t, r.IsReady())
 	})
 
 	t.Run("not running in booting state", func(t *testing.T) {
@@ -82,7 +82,7 @@ func TestRunner_IsRunning(t *testing.T) {
 		err := r.fsm.Transition(finitestate.StatusBooting)
 		require.NoError(t, err)
 
-		assert.False(t, r.IsRunning())
+		assert.False(t, r.IsReady())
 	})
 
 	t.Run("running after transition to running state", func(t *testing.T) {
@@ -90,7 +90,7 @@ func TestRunner_IsRunning(t *testing.T) {
 		r := h.runner
 
 		h.transitionToRunning()
-		assert.True(t, r.IsRunning())
+		assert.True(t, r.IsReady())
 	})
 
 	t.Run("not running in stopping state", func(t *testing.T) {
@@ -98,12 +98,12 @@ func TestRunner_IsRunning(t *testing.T) {
 		r := h.runner
 
 		h.transitionToRunning()
-		require.True(t, r.IsRunning())
+		require.True(t, r.IsReady())
 
 		err := r.fsm.Transition(finitestate.StatusStopping)
 		require.NoError(t, err)
 
-		assert.False(t, r.IsRunning())
+		assert.False(t, r.IsReady())
 	})
 
 	t.Run("not running in stopped state", func(t *testing.T) {
@@ -116,7 +116,7 @@ func TestRunner_IsRunning(t *testing.T) {
 		err = r.fsm.Transition(finitestate.StatusStopped)
 		require.NoError(t, err)
 
-		assert.False(t, r.IsRunning())
+		assert.False(t, r.IsReady())
 	})
 
 	t.Run("running state during full lifecycle", func(t *testing.T) {
@@ -125,7 +125,7 @@ func TestRunner_IsRunning(t *testing.T) {
 		defer h.cancel()
 
 		// Initially not running
-		assert.False(t, r.IsRunning())
+		assert.False(t, r.IsReady())
 
 		// Start runner in background
 		runErrCh := make(chan error, 1)
@@ -135,7 +135,7 @@ func TestRunner_IsRunning(t *testing.T) {
 
 		// Wait for runner to become running
 		require.Eventually(t, func() bool {
-			return r.IsRunning()
+			return r.IsReady()
 		}, 1*time.Second, 10*time.Millisecond, "Runner should be running")
 
 		// Stop the runner
@@ -143,7 +143,7 @@ func TestRunner_IsRunning(t *testing.T) {
 
 		// Wait for runner to stop being running
 		require.Eventually(t, func() bool {
-			return !r.IsRunning()
+			return !r.IsReady()
 		}, 200*time.Millisecond, 10*time.Millisecond, "Runner should stop running")
 
 		// Wait for Run to complete
@@ -155,7 +155,7 @@ func TestRunner_IsRunning(t *testing.T) {
 		}
 
 		// Finally not running
-		assert.False(t, r.IsRunning())
+		assert.False(t, r.IsReady())
 	})
 }
 
@@ -295,7 +295,7 @@ func TestRunner_GetStateChan(t *testing.T) {
 
 		// Wait for runner to start
 		require.Eventually(t, func() bool {
-			return r.IsRunning()
+			return r.IsReady()
 		}, 1*time.Second, 10*time.Millisecond, "Runner should be running")
 
 		// Stop the runner
@@ -334,7 +334,7 @@ func TestRunner_GetStateChan(t *testing.T) {
 }
 
 func TestRunner_StateConsistency(t *testing.T) {
-	t.Run("GetState and IsRunning consistency", func(t *testing.T) {
+	t.Run("GetState and IsReady consistency", func(t *testing.T) {
 		h := newRunnerTestHarness(t, testutil.GetRandomListeningPort(t))
 		r := h.runner
 
@@ -356,9 +356,9 @@ func TestRunner_StateConsistency(t *testing.T) {
 			assert.Equal(t, expectedState, actualState)
 
 			expectedRunning := (expectedState == finitestate.StatusRunning)
-			actualRunning := r.IsRunning()
+			actualRunning := r.IsReady()
 			assert.Equal(t, expectedRunning, actualRunning,
-				"IsRunning() should return %t when state is %s", expectedRunning, expectedState)
+				"IsReady() should return %t when state is %s", expectedRunning, expectedState)
 		}
 	})
 
@@ -424,7 +424,7 @@ func (h *stateTestHarness) startRunner() {
 
 func (h *stateTestHarness) waitForRunningState() {
 	require.Eventually(h.t, func() bool {
-		return h.runner.IsRunning()
+		return h.runner.IsReady()
 	}, 1*time.Second, 10*time.Millisecond, "Runner should reach Running state")
 }
 
@@ -462,7 +462,7 @@ func TestRunner_StateIntegration(t *testing.T) {
 
 		// Initial state verification
 		assert.Equal(t, finitestate.StatusNew, r.GetState())
-		assert.False(t, r.IsRunning())
+		assert.False(t, r.IsReady())
 
 		// Start the runner
 		h.startRunner()
@@ -470,14 +470,14 @@ func TestRunner_StateIntegration(t *testing.T) {
 		// Wait for running state
 		h.waitForRunningState()
 		assert.Equal(t, finitestate.StatusRunning, r.GetState())
-		assert.True(t, r.IsRunning())
+		assert.True(t, r.IsReady())
 
 		// Stop and wait for completion
 		h.stopAndWaitForCompletion()
 
 		// Final state verification
 		assert.Equal(t, finitestate.StatusStopped, r.GetState())
-		assert.False(t, r.IsRunning())
+		assert.False(t, r.IsReady())
 
 		// Wait for all 5 expected states to be collected
 		require.Eventually(t, func() bool {

--- a/internal/server/runnables/listeners/http/runner.go
+++ b/internal/server/runnables/listeners/http/runner.go
@@ -33,6 +33,7 @@ type Runner struct {
 var (
 	_ supervisor.Runnable          = (*Runner)(nil)
 	_ supervisor.Stateable         = (*Runner)(nil)
+	_ supervisor.Readiness         = (*Runner)(nil)
 	_ orchestrator.SagaParticipant = (*Runner)(nil)
 )
 
@@ -85,7 +86,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		}
 	}()
 
-	err := r.waitForClusterRunning(ctx, r.clusterReadyTimeout)
+	err := r.waitForClusterReady(ctx, r.clusterReadyTimeout)
 	if err != nil {
 		return fmt.Errorf("failed to wait for HTTP cluster to start running: %w", err)
 	}
@@ -128,9 +129,9 @@ func (r *Runner) shutdown() error {
 	return nil
 }
 
-// waitForClusterRunning waits for the cluster to return a positive IsRunning()
-func (r *Runner) waitForClusterRunning(ctx context.Context, timeout time.Duration) error {
-	logger := r.logger.WithGroup("waitForClusterRunning")
+// waitForClusterReady waits for the cluster to return a positive IsReady()
+func (r *Runner) waitForClusterReady(ctx context.Context, timeout time.Duration) error {
+	logger := r.logger.WithGroup("waitForClusterReady")
 
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
@@ -150,7 +151,7 @@ func (r *Runner) waitForClusterRunning(ctx context.Context, timeout time.Duratio
 			return ctx.Err()
 		case <-ticker.C:
 			// every N check if the cluster is running, and continue
-			if r.cluster.IsRunning() {
+			if r.cluster.IsReady() {
 				logger.Debug("HTTP cluster is now running")
 				return nil
 			}

--- a/internal/server/runnables/listeners/http/runner.go
+++ b/internal/server/runnables/listeners/http/runner.go
@@ -87,12 +87,10 @@ func (r *Runner) Run(ctx context.Context) error {
 	}()
 
 	err := r.waitForClusterReady(ctx, r.clusterReadyTimeout)
+	r.mutex.Unlock()
 	if err != nil {
 		return fmt.Errorf("failed to wait for HTTP cluster to become ready: %w", err)
 	}
-
-	// unlock now that the cluster is running
-	r.mutex.Unlock()
 
 	// block here until the run context is canceled
 	<-ctx.Done()

--- a/internal/server/runnables/listeners/http/runner.go
+++ b/internal/server/runnables/listeners/http/runner.go
@@ -88,7 +88,7 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	err := r.waitForClusterReady(ctx, r.clusterReadyTimeout)
 	if err != nil {
-		return fmt.Errorf("failed to wait for HTTP cluster to start running: %w", err)
+		return fmt.Errorf("failed to wait for HTTP cluster to become ready: %w", err)
 	}
 
 	// unlock now that the cluster is running
@@ -143,16 +143,16 @@ func (r *Runner) waitForClusterReady(ctx context.Context, timeout time.Duration)
 		select {
 		case <-timeoutCtx.Done():
 			if timeoutCtx.Err() == context.DeadlineExceeded {
-				logger.Warn("Timeout waiting for HTTP cluster to start running")
+				logger.Warn("Timeout waiting for HTTP cluster to become ready")
 			}
 			return timeoutCtx.Err()
 		case <-ctx.Done():
 			logger.Debug("Run context canceled")
 			return ctx.Err()
 		case <-ticker.C:
-			// every N check if the cluster is running, and continue
+			// periodically check if the cluster is ready
 			if r.cluster.IsReady() {
-				logger.Debug("HTTP cluster is now running")
+				logger.Debug("HTTP cluster is now ready")
 				return nil
 			}
 		}

--- a/internal/server/runnables/listeners/http/runner_test.go
+++ b/internal/server/runnables/listeners/http/runner_test.go
@@ -97,7 +97,7 @@ func TestRunner_RunAndStop(t *testing.T) {
 
 	// Wait for the runner to start
 	assert.Eventually(t, func() bool {
-		return runner.IsRunning()
+		return runner.IsReady()
 	}, 1*time.Second, 10*time.Millisecond)
 
 	// Stop the runner
@@ -113,6 +113,6 @@ func TestRunner_RunAndStop(t *testing.T) {
 
 	// Verify it's stopped
 	assert.Eventually(t, func() bool {
-		return !runner.IsRunning()
+		return !runner.IsReady()
 	}, 1*time.Second, 10*time.Millisecond, "runner should stop")
 }

--- a/internal/server/runnables/listeners/http/runner_test.go
+++ b/internal/server/runnables/listeners/http/runner_test.go
@@ -116,3 +116,44 @@ func TestRunner_RunAndStop(t *testing.T) {
 		return !runner.IsReady()
 	}, 1*time.Second, 10*time.Millisecond, "runner should stop")
 }
+
+// TestRunner_Run_StartupTimeoutReleasesMutex regression test: when
+// waitForClusterReady returns an error during Run, the mutex acquired
+// at the start of Run must still be released. Otherwise Stop() and the
+// SagaParticipant methods deadlock forever on r.mutex.Lock().
+func TestRunner_Run_StartupTimeoutReleasesMutex(t *testing.T) {
+	runner, err := NewRunner()
+	require.NoError(t, err)
+	// Force waitForClusterReady to time out before the cluster can become ready.
+	runner.clusterReadyTimeout = time.Microsecond
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- runner.Run(ctx) }()
+
+	select {
+	case err := <-runErr:
+		require.Error(t, err)
+		require.ErrorContains(
+			t,
+			err,
+			"failed to wait for HTTP cluster to become ready",
+		)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after readiness timeout")
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		runner.Stop()
+		close(stopDone)
+	}()
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("Stop deadlocked — Run() leaked the mutex on its error path")
+	}
+}

--- a/internal/server/runnables/listeners/http/saga.go
+++ b/internal/server/runnables/listeners/http/saga.go
@@ -99,7 +99,7 @@ func (r *Runner) sendConfigToCluster(ctx context.Context, cfg *cfg.Adapter) erro
 	}
 
 	// Wait for cluster to finish processing and return to running state
-	err := r.waitForClusterRunning(ctx, r.clusterReadyTimeout)
+	err := r.waitForClusterReady(ctx, r.clusterReadyTimeout)
 	if err != nil {
 		return err
 	}

--- a/internal/server/runnables/listeners/http/saga.go
+++ b/internal/server/runnables/listeners/http/saga.go
@@ -98,7 +98,7 @@ func (r *Runner) sendConfigToCluster(ctx context.Context, cfg *cfg.Adapter) erro
 		return fmt.Errorf("timeout sending configuration to cluster after %v", r.siphonTimeout)
 	}
 
-	// Wait for cluster to finish processing and return to running state
+	// Wait for cluster to finish processing and become ready
 	err := r.waitForClusterReady(ctx, r.clusterReadyTimeout)
 	if err != nil {
 		return err

--- a/internal/server/runnables/listeners/http/saga_test.go
+++ b/internal/server/runnables/listeners/http/saga_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/atlanticdynamic/firelynx/internal/server/runnables/listeners/http/cfg"
+	"github.com/atlanticdynamic/firelynx/internal/testutil"
 	"github.com/robbyt/go-supervisor/runnables/httpcluster"
 	"github.com/robbyt/go-supervisor/runnables/httpserver"
 	"github.com/stretchr/testify/assert"
@@ -371,5 +372,49 @@ func TestRunner_SendConfigToCluster(t *testing.T) {
 		err = runner.sendConfigToCluster(ctx, adapter)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "timeout sending configuration to cluster")
+	})
+
+	t.Run("happy path through running cluster", func(t *testing.T) {
+		runner, err := NewRunner()
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		// Boot the runner so the cluster is alive and ready to consume the
+		// siphon. This also makes waitForClusterReady return immediately.
+		runErr := make(chan error, 1)
+		go func() { runErr <- runner.Run(ctx) }()
+		assert.Eventually(t, func() bool { return runner.IsReady() },
+			2*time.Second, 10*time.Millisecond, "runner should become ready")
+
+		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		route1, err := httpserver.NewRouteFromHandlerFunc("route1", "/test", testHandler)
+		require.NoError(t, err)
+
+		adapter := &cfg.Adapter{
+			TxID: "test-tx-happy",
+			Listeners: map[string]cfg.ListenerConfig{
+				"listener1": {
+					ID:      "listener1",
+					Address: testutil.GetRandomListeningPort(t),
+				},
+			},
+			Routes: map[string][]httpserver.Route{
+				"listener1": {*route1},
+			},
+		}
+
+		require.NoError(t, runner.sendConfigToCluster(ctx, adapter))
+
+		runner.Stop()
+		select {
+		case err := <-runErr:
+			require.NoError(t, err)
+		case <-time.After(2 * time.Second):
+			t.Fatal("runner did not stop within timeout")
+		}
 	})
 }

--- a/internal/server/runnables/listeners/http/saga_test.go
+++ b/internal/server/runnables/listeners/http/saga_test.go
@@ -256,7 +256,7 @@ func TestRunner_WaitForClusterRunning(t *testing.T) {
 		runner.cluster = cluster
 
 		ctx := t.Context()
-		err = runner.waitForClusterRunning(ctx, 50*time.Millisecond)
+		err = runner.waitForClusterReady(ctx, 50*time.Millisecond)
 		require.Error(t, err)
 		assert.Equal(t, context.DeadlineExceeded, err)
 	})
@@ -269,7 +269,7 @@ func TestRunner_WaitForClusterRunning(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		cancel() // Cancel immediately
 
-		err = runner.waitForClusterRunning(ctx, 1*time.Second)
+		err = runner.waitForClusterReady(ctx, 1*time.Second)
 		require.Error(t, err)
 		assert.Equal(t, context.Canceled, err)
 	})
@@ -289,11 +289,11 @@ func TestRunner_WaitForClusterRunning(t *testing.T) {
 
 		// Use assert.Eventually to wait for cluster to be ready
 		assert.Eventually(t, func() bool {
-			return runner.cluster.IsRunning()
+			return runner.cluster.IsReady()
 		}, 1*time.Second, 10*time.Millisecond)
 
-		// Now waitForClusterRunning should succeed immediately
-		err = runner.waitForClusterRunning(ctx, 100*time.Millisecond)
+		// Now waitForClusterReady should succeed immediately
+		err = runner.waitForClusterReady(ctx, 100*time.Millisecond)
 		require.NoError(t, err)
 
 		// Clean shutdown

--- a/internal/server/runnables/listeners/http/state.go
+++ b/internal/server/runnables/listeners/http/state.go
@@ -7,9 +7,9 @@ func (r *Runner) GetState() string {
 	return r.cluster.GetState()
 }
 
-// IsRunning returns whether the runner is running
-func (r *Runner) IsRunning() bool {
-	return r.cluster.IsRunning()
+// IsReady returns whether the runner is running
+func (r *Runner) IsReady() bool {
+	return r.cluster.IsReady()
 }
 
 // GetStateChan returns a channel that emits state changes

--- a/internal/server/runnables/listeners/http/state_test.go
+++ b/internal/server/runnables/listeners/http/state_test.go
@@ -14,7 +14,7 @@ func TestRunner_GetState(t *testing.T) {
 
 	// Initial state should be "New" based on the implementation
 	assert.Equal(t, "New", runner.GetState())
-	assert.False(t, runner.IsRunning())
+	assert.False(t, runner.IsReady())
 }
 
 func TestRunner_GetStateChan(t *testing.T) {

--- a/internal/server/runnables/txmgr/orchestrator/participants_mocks_test.go
+++ b/internal/server/runnables/txmgr/orchestrator/participants_mocks_test.go
@@ -40,7 +40,7 @@ func (m *mockSagaParticipant) GetState() string {
 	return args.String(0)
 }
 
-func (m *mockSagaParticipant) IsRunning() bool {
+func (m *mockSagaParticipant) IsReady() bool {
 	args := m.Called()
 	return args.Bool(0)
 }
@@ -87,7 +87,7 @@ func (p *ConflictingParticipant) String() string                { return p.name 
 func (p *ConflictingParticipant) Run(ctx context.Context) error { return nil }
 func (p *ConflictingParticipant) Stop()                         {}
 func (p *ConflictingParticipant) GetState() string              { return "running" }
-func (p *ConflictingParticipant) IsRunning() bool               { return true }
+func (p *ConflictingParticipant) IsReady() bool                 { return true }
 func (p *ConflictingParticipant) GetStateChan(ctx context.Context) <-chan string {
 	ch := make(chan string, 1)
 	ch <- "running"
@@ -110,7 +110,7 @@ func (p *ConflictingParticipant) CompensateConfig(
 }
 func (p *ConflictingParticipant) CommitConfig(ctx context.Context) error { return nil }
 
-func (p *ConflictingParticipant) Reload() {} // This causes the conflict
+func (p *ConflictingParticipant) Reload(ctx context.Context) error { return nil } // This causes the conflict
 
 // MockReloadParticipant is a mock implementation of SagaParticipant that can be configured to fail reload
 type MockReloadParticipant struct {
@@ -169,8 +169,8 @@ func (m *MockReloadParticipant) CommitConfig(ctx context.Context) error {
 	return args.Error(0)
 }
 
-// IsRunning implements supervisor.Readiness
-func (m *MockReloadParticipant) IsRunning() bool {
+// IsReady implements supervisor.Readiness
+func (m *MockReloadParticipant) IsReady() bool {
 	m.Called()
 	return m.running
 }

--- a/internal/server/runnables/txmgr/orchestrator/participants_test.go
+++ b/internal/server/runnables/txmgr/orchestrator/participants_test.go
@@ -49,7 +49,7 @@ func TestSagaParticipantInterface_ApplyPendingConfigFromMocks(t *testing.T) {
 	// Setup expectations
 	participant.On("CommitConfig", mock.Anything).Return(nil)
 	participant.On("GetState").Return("running")
-	participant.On("IsRunning").Return(true)
+	participant.On("IsReady").Return(true)
 
 	// Register participant
 	err := orchestrator.RegisterParticipant(participant)
@@ -117,8 +117,8 @@ func TestTriggerReload_SuccessFromMocks(t *testing.T) {
 	participant2.On("CommitConfig", mock.Anything).Return(nil)
 	participant1.On("GetState").Return("running")
 	participant2.On("GetState").Return("running")
-	participant1.On("IsRunning").Return(true)
-	participant2.On("IsRunning").Return(true)
+	participant1.On("IsReady").Return(true)
+	participant2.On("IsReady").Return(true)
 
 	// Register participants
 	err = orchestrator.RegisterParticipant(participant1)
@@ -177,8 +177,8 @@ func TestTriggerReload_FailureFromMocks(t *testing.T) {
 		Return(fmt.Errorf("failed to apply pending config"))
 	participant1.On("GetState").Return("running")
 	participant2.On("GetState").Maybe().Return("failed")
-	participant1.On("IsRunning").Maybe().Return(true)
-	participant2.On("IsRunning").Maybe().Return(false)
+	participant1.On("IsReady").Maybe().Return(true)
+	participant2.On("IsReady").Maybe().Return(false)
 
 	// Register participants
 	err = orchestrator.RegisterParticipant(participant1)

--- a/internal/server/runnables/txmgr/orchestrator/saga.go
+++ b/internal/server/runnables/txmgr/orchestrator/saga.go
@@ -24,13 +24,14 @@ const (
 )
 
 // SagaParticipant defines the interface for components participating
-// in configuration transactions. It extends Runnable and Stateable from supervisor
-// to ensure components have the necessary lifecycle management capabilities.
-// Note that SagaParticipant SHOULD NOT implement supervisor.Reloadable to avoid
-// conflicts with the CommitConfig method.
+// in configuration transactions. It extends Runnable, Stateable, and Readiness
+// from supervisor to ensure components have the necessary lifecycle management
+// capabilities. Note that SagaParticipant SHOULD NOT implement
+// supervisor.Reloadable to avoid conflicts with the CommitConfig method.
 type SagaParticipant interface {
 	supervisor.Runnable
 	supervisor.Stateable
+	supervisor.Readiness
 
 	// StageConfig processes a validated configuration transaction
 	// by preparing the component to apply the changes. This is called
@@ -179,7 +180,7 @@ func (o *SagaOrchestrator) registerAndExecuteParticipants(
 		}
 
 		// Check if participant is ready
-		if err := o.waitForRunning(ctx, participant, name); err != nil {
+		if err := o.waitForReady(ctx, participant, name); err != nil {
 			errz = append(errz, fmt.Errorf("participant %s not ready: %w", name, err))
 
 			// Mark participant as failed
@@ -347,11 +348,12 @@ func (o *SagaOrchestrator) GetTransactionStatus(txID string) (map[string]any, er
 	return status, nil
 }
 
-// waitForRunning waits for the given participant to return to running state
-// or until the timeout is reached. Returns an error if the timeout expires.
-func (o *SagaOrchestrator) waitForRunning(
+// waitForReady waits for the given participant to become ready (post-startup
+// phase complete) or until the timeout is reached. Returns an error if the
+// timeout expires.
+func (o *SagaOrchestrator) waitForReady(
 	ctx context.Context,
-	stateable supervisor.Stateable,
+	readiness supervisor.Readiness,
 	name string,
 ) error {
 	// Use default values
@@ -367,15 +369,15 @@ func (o *SagaOrchestrator) waitForRunning(
 		"name", name, "timeout", reloadTimeout)
 
 	for {
-		// Check if participant is running
-		if stateable.IsRunning() {
-			o.logger.Debug("Participant is now running after reload", "name", name)
+		// Check if participant is ready
+		if readiness.IsReady() {
+			o.logger.Debug("Participant is now ready after reload", "name", name)
 			return nil
 		}
 
 		// Check if we've reached the deadline
 		if time.Now().After(deadline) {
-			return fmt.Errorf("timeout waiting for participant to be running after reload")
+			return fmt.Errorf("timeout waiting for participant to be ready after reload")
 		}
 
 		// Check if context is done
@@ -492,19 +494,20 @@ func (o *SagaOrchestrator) TriggerReload(ctx context.Context) error {
 		// Log post-reload state if available
 		if stateable, ok := participant.(supervisor.Stateable); ok {
 			logger.Debug("Post-reload state", "state", stateable.GetState())
+		}
 
-			// Wait for participant to be running again
-			if err := o.waitForRunning(ctx, stateable, name); err != nil {
-				logger.Error(
-					"Participant failed to return to running state after reload",
-					"error", err,
-				)
-				reloadErrors = append(
-					reloadErrors,
-					fmt.Errorf("participant %s failed to return to running state: %w", name, err),
-				)
-				// Continue with other participants despite errors
-			}
+		// Wait for participant to be ready again. SagaParticipant embeds
+		// supervisor.Readiness, so this is statically satisfied.
+		if err := o.waitForReady(ctx, participant, name); err != nil {
+			logger.Error(
+				"Participant failed to return to ready state after reload",
+				"error", err,
+			)
+			reloadErrors = append(
+				reloadErrors,
+				fmt.Errorf("participant %s failed to return to ready state: %w", name, err),
+			)
+			// Continue with other participants despite errors
 		}
 	}
 

--- a/internal/server/runnables/txmgr/orchestrator/saga.go
+++ b/internal/server/runnables/txmgr/orchestrator/saga.go
@@ -365,7 +365,7 @@ func (o *SagaOrchestrator) waitForReady(
 	ticker := time.NewTicker(retryInterval)
 	defer ticker.Stop()
 
-	o.logger.Debug("Waiting for participant to be running after reload",
+	o.logger.Debug("Waiting for participant to be ready after reload",
 		"name", name, "timeout", reloadTimeout)
 
 	for {

--- a/internal/server/runnables/txmgr/orchestrator/saga_test.go
+++ b/internal/server/runnables/txmgr/orchestrator/saga_test.go
@@ -728,3 +728,53 @@ func TestFinalizeSuccessfulTransaction_TriggerReloadFails(t *testing.T) {
 
 	participant.AssertExpectations(t)
 }
+
+// TestFinalizeSuccessfulTransaction_TriggerReloadWaitForReadyFails covers the
+// path inside TriggerReload where CommitConfig succeeds but the participant
+// never reports IsReady. This exercises the waitForReady-fail branch
+// (reloadErrors append + Error log) inside the reload loop.
+func TestFinalizeSuccessfulTransaction_TriggerReloadWaitForReadyFails(t *testing.T) {
+	handler := slog.NewTextHandler(os.Stdout, nil)
+	storage := txstorage.NewMemoryStorage()
+	orchestrator := NewSagaOrchestrator(storage, handler)
+
+	// Short context timeout so waitForReady's <-ctx.Done() fires before
+	// DefaultReloadTimeout (30s).
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	cfg, err := config.NewFromProto(&pb.ServerConfig{})
+	require.NoError(t, err, "unable to create empty config")
+	tx, err := transaction.New(transaction.SourceTest, "test", "req-123", cfg, handler)
+	require.NoError(t, err, "unable to create transaction")
+
+	err = tx.RunValidation()
+	require.NoError(t, err, "transaction validation should succeed")
+	err = tx.BeginExecution()
+	require.NoError(t, err, "transaction should begin execution")
+
+	participant := &MockNotRunningParticipant{
+		MockParticipant: *NewMockParticipant("not-ready-after-commit"),
+	}
+	// CommitConfig succeeds; the participant just never reports ready.
+	participant.On("CommitConfig", mock.Anything).Return(nil)
+
+	err = orchestrator.RegisterParticipant(participant)
+	require.NoError(t, err, "participant registration should succeed")
+
+	err = tx.RegisterParticipant("not-ready-after-commit")
+	require.NoError(t, err, "participant registration should succeed")
+	participantState, err := tx.GetParticipants().GetOrCreate("not-ready-after-commit")
+	require.NoError(t, err, "participant state creation should succeed")
+	err = participantState.Execute()
+	require.NoError(t, err, "participant execution should start")
+	err = participantState.MarkSucceeded()
+	require.NoError(t, err, "participant should be marked as succeeded")
+
+	err = orchestrator.finalizeSuccessfulTransaction(ctx, tx)
+	require.Error(t, err, "finalizeSuccessfulTransaction should fail when waitForReady times out")
+	require.ErrorContains(t, err, "failed to return to ready state",
+		"error should mention readiness failure from TriggerReload")
+
+	participant.AssertExpectations(t)
+}

--- a/internal/server/runnables/txmgr/orchestrator/saga_test.go
+++ b/internal/server/runnables/txmgr/orchestrator/saga_test.go
@@ -79,7 +79,7 @@ func (m *MockParticipant) GetStateChan(ctx context.Context) <-chan string {
 	return stateCh
 }
 
-func (m *MockParticipant) IsRunning() bool {
+func (m *MockParticipant) IsReady() bool {
 	return true
 }
 
@@ -149,7 +149,7 @@ func (p *conflictingParticipant) String() string                { return p.name 
 func (p *conflictingParticipant) Run(ctx context.Context) error { return nil }
 func (p *conflictingParticipant) Stop()                         {}
 func (p *conflictingParticipant) GetState() string              { return "running" }
-func (p *conflictingParticipant) IsRunning() bool               { return true }
+func (p *conflictingParticipant) IsReady() bool                 { return true }
 func (p *conflictingParticipant) GetStateChan(ctx context.Context) <-chan string {
 	ch := make(chan string, 1)
 	ch <- "running"
@@ -171,7 +171,7 @@ func (p *conflictingParticipant) CompensateConfig(
 }
 func (p *conflictingParticipant) CommitConfig(ctx context.Context) error { return nil }
 
-func (p *conflictingParticipant) Reload() {} // This causes the conflict
+func (p *conflictingParticipant) Reload(ctx context.Context) error { return nil } // This causes the conflict
 
 func TestProcessTransaction_Success(t *testing.T) {
 	handler := slog.NewTextHandler(os.Stdout, nil)
@@ -559,7 +559,7 @@ type MockNotRunningParticipant struct {
 	MockParticipant
 }
 
-func (m *MockNotRunningParticipant) IsRunning() bool {
+func (m *MockNotRunningParticipant) IsReady() bool {
 	return false
 }
 
@@ -573,8 +573,8 @@ func TestWaitForRunning_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // Cancel immediately
 
-	err := orchestrator.waitForRunning(ctx, participant, "test")
-	require.Error(t, err, "waitForRunning should fail when context is cancelled")
+	err := orchestrator.waitForReady(ctx, participant, "test")
+	require.Error(t, err, "waitForReady should fail when context is cancelled")
 	assert.Equal(t, context.Canceled, err, "error should be context.Canceled")
 }
 
@@ -590,8 +590,8 @@ func TestWaitForRunning_Timeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), time.Millisecond)
 	defer cancel()
 
-	err := orchestrator.waitForRunning(ctx, participant, "test")
-	require.Error(t, err, "waitForRunning should fail when context times out")
+	err := orchestrator.waitForReady(ctx, participant, "test")
+	require.Error(t, err, "waitForReady should fail when context times out")
 	assert.ErrorIs(t, err, context.DeadlineExceeded, "error should be context deadline exceeded")
 }
 

--- a/internal/server/runnables/txmgr/runner.go
+++ b/internal/server/runnables/txmgr/runner.go
@@ -30,6 +30,7 @@ const (
 var (
 	_ supervisor.Runnable  = (*Runner)(nil)
 	_ supervisor.Stateable = (*Runner)(nil)
+	_ supervisor.Readiness = (*Runner)(nil)
 )
 
 // Runner implements the transaction manager using a siphon pattern

--- a/internal/server/runnables/txmgr/runner_saga_test.go
+++ b/internal/server/runnables/txmgr/runner_saga_test.go
@@ -84,7 +84,7 @@ func TestRunnerShutdownTimeout(t *testing.T) {
 
 		// Wait for runner to start
 		assert.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, 5*time.Second, 10*time.Millisecond)
 
 		// Cancel context to trigger shutdown
@@ -127,7 +127,7 @@ func TestRunnerShutdownTimeout(t *testing.T) {
 
 		// Wait for runner to start
 		assert.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, 5*time.Second, 10*time.Millisecond)
 
 		// Cancel context to trigger shutdown

--- a/internal/server/runnables/txmgr/runner_test.go
+++ b/internal/server/runnables/txmgr/runner_test.go
@@ -60,7 +60,7 @@ func (h *testHarness) start() {
 
 	// Wait for runner to be in Running state
 	assert.Eventually(h.t, func() bool {
-		return h.runner.IsRunning()
+		return h.runner.IsReady()
 	}, 5*time.Second, 10*time.Millisecond, "runner should reach Running state")
 }
 
@@ -159,7 +159,7 @@ func TestRunnerRunLifecycle(t *testing.T) {
 		return h.runner.GetState() == finitestate.StatusRunning
 	}, time.Second, 10*time.Millisecond)
 
-	assert.True(t, h.runner.IsRunning())
+	assert.True(t, h.runner.IsReady())
 
 	cancel()
 
@@ -173,7 +173,7 @@ func TestRunnerRunLifecycle(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		return h.runner.GetState() == finitestate.StatusStopped
 	}, time.Second, 10*time.Millisecond, "runner should reach Stopped state")
-	assert.False(t, h.runner.IsRunning())
+	assert.False(t, h.runner.IsReady())
 }
 
 func TestRunnerConfigUpdate(t *testing.T) {
@@ -244,7 +244,7 @@ func TestRunnerStateChan(t *testing.T) {
 		}
 
 		// Verify runner is now running
-		assert.True(t, runner.IsRunning())
+		assert.True(t, runner.IsReady())
 
 		// Trigger shutdown
 		runCancel()
@@ -277,7 +277,7 @@ func TestRunnerStateChan(t *testing.T) {
 		assert.Eventually(t, func() bool {
 			return runner.GetState() == finitestate.StatusStopped
 		}, time.Second, 10*time.Millisecond, "runner should reach Stopped state")
-		assert.False(t, runner.IsRunning())
+		assert.False(t, runner.IsReady())
 	})
 }
 
@@ -295,7 +295,7 @@ func TestRunnerMultipleConcurrentTransactions(t *testing.T) {
 
 	// Wait for runner to start
 	assert.Eventually(t, func() bool {
-		return runner.IsRunning()
+		return runner.IsReady()
 	}, 5*time.Second, 10*time.Millisecond)
 
 	txSiphon := runner.GetTransactionSiphon()
@@ -403,7 +403,7 @@ func TestRunnerErrorHandling(t *testing.T) {
 
 	// Runner should continue running despite error
 	assert.Eventually(t, func() bool {
-		return h.runner.IsRunning()
+		return h.runner.IsReady()
 	}, 5*time.Second, 10*time.Millisecond, "runner should continue running")
 
 	// Clean shutdown

--- a/internal/server/runnables/txmgr/state.go
+++ b/internal/server/runnables/txmgr/state.go
@@ -6,8 +6,8 @@ import (
 	"github.com/atlanticdynamic/firelynx/internal/server/finitestate"
 )
 
-// IsRunning returns true if the runner is in the Running state
-func (r *Runner) IsRunning() bool {
+// IsReady returns true if the runner is in the Running state
+func (r *Runner) IsReady() bool {
 	return r.fsm.GetState() == finitestate.StatusRunning
 }
 


### PR DESCRIPTION
## Summary

- Bumps `github.com/robbyt/go-supervisor` from v0.0.19 → v0.0.21
- Migrates firelynx to the new API (`Reload(ctx) error`, `IsRunning` → `IsReady`, explicit `Readiness` interface)
- **Eliminates the Ctrl-C shutdown stall** that surfaced as `WARN fsm.broadcast: Timeout subscriber blocked; state delivery timed out` at INFO log level. Repro before: 5–10s stall, two WARNs. Repro after: 3–4ms shutdown, zero WARNs across 3 runs.

## Why

The shutdown race lived entirely in go-supervisor (slow state-channel reader during Stop ordering). Upstream fixes that resolve it:

- #96 per-runnable `Stop()` bounded by shutdown deadline
- #97 break circular wait between `ShutdownSender` and shutdown manager
- #98 honor ctx cancellation in `Run`'s startup loop
- #100 composite uses FSM admission gate instead of `reloadMu`

Earlier work on `rterhaar/fix-demo-apps` patched this on the firelynx side by relaxing `internal/server/finitestate/machine.go` (buffer 1→8, `WithBroadcastTimeout(0)`). With v0.0.21 that workaround is unnecessary — confirmed by running the original repro at INFO with stock buffer/timeout values.

## API migration

Breaking changes in v0.0.21 ([release notes](https://github.com/robbyt/go-supervisor/releases/tag/v0.0.21)):

- `Reloadable.Reload()` → `Reload(ctx) error` (#111). One implementation: `cfgfileloader.Runner`. Now surfaces real errors from `loadConfigFromDisk`/`validate` instead of swallowing them via duplicate `r.logger.Error`.
- `Stateable` no longer embeds `Readiness`; the two are orthogonal (#105). Added explicit `_ supervisor.Readiness` interface guards on the four runners (`cfgfileloader`, `cfgservice`, `txmgr`, `http listener`). `SagaParticipant` now embeds `supervisor.Readiness`.
- `Readiness.IsRunning()` → `Readiness.IsReady()` (#105). ~40 callsites across implementations and tests.
- Helper renames: `waitForRunning` → `waitForReady` (saga.go, parameter narrowed from `Stateable` to `Readiness`), `waitForClusterRunning` → `waitForClusterReady` (http runner).

`ReloadableWithConfig` (#104) is not used in firelynx — no change needed.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `make lint` — 0 issues
- [x] `make test` — 54 packages pass
- [x] `make test-integration` — all green
- [x] Shutdown race repro: `firelynx server -c examples/config/mcp/mcp-typed-builtins.toml` → SIGINT, 3 iterations, zero WARNs and 3–4ms shutdown each