### PR TITLE
Fix nil pointer TOML encoding after go-toml v2.4.2 bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/log v0.4.2
 	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
-	github.com/pelletier/go-toml/v2 v2.3.1
+	github.com/pelletier/go-toml/v2 v2.4.2
 	github.com/robbyt/go-fsm/v2 v2.5.0
 	github.com/robbyt/go-loglater v0.2.0
 	github.com/robbyt/go-polyscript v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/u
 github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
-github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
-github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pelletier/go-toml/v2 v2.4.2 h1:M2fKKbmyvI+hGId/D0W64qDBMVhJnNR10O5gIbMc//Q=
+github.com/pelletier/go-toml/v2 v2.4.2/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -227,6 +227,10 @@ func (c *Client) ValidateConfig(ctx context.Context, config *pb.ServerConfig) (b
 
 // SaveConfig saves a configuration to a file
 func (c *Client) SaveConfig(config *pb.ServerConfig, outputPath string) error {
+	if config == nil {
+		return ErrNilConfig
+	}
+
 	// Convert to TOML
 	tomlBytes, err := toml.Marshal(config)
 	if err != nil {
@@ -244,6 +248,10 @@ func (c *Client) SaveConfig(config *pb.ServerConfig, outputPath string) error {
 
 // FormatConfig formats a configuration as a TOML string
 func (c *Client) FormatConfig(config *pb.ServerConfig) (string, error) {
+	if config == nil {
+		return "", ErrNilConfig
+	}
+
 	// Convert to TOML
 	tomlBytes, err := toml.Marshal(config)
 	if err != nil {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -211,7 +211,7 @@ func TestFormatConfig(t *testing.T) {
 		{
 			name:    "nil config",
 			config:  nil,
-			wantErr: false, // TOML can marshal nil as empty
+			wantErr: true, // nil config cannot be encoded to TOML
 		},
 	}
 

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -8,4 +8,5 @@ var (
 	ErrUnsupportedNetwork   = errors.New("unsupported network type")
 	ErrConnectionFailed     = errors.New("failed to connect to server")
 	ErrConfigRejected       = errors.New("server rejected configuration")
+	ErrNilConfig            = errors.New("config is nil")
 )


### PR DESCRIPTION
go-toml/v2 v2.4.x changed Marshal to return an error ("toml: cannot
encode a nil pointer") when passed a nil pointer, whereas v2.3.1
produced output. This broke TestFormatConfig/nil_config in the
dependency-update PR.

Guard against nil in SaveConfig and FormatConfig, returning a clear
ErrNilConfig sentinel instead of leaking the library's internal error
(or writing a bogus file). Update the test to expect an error for a
nil config.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Fs8rbaVQJiLmDns1eA4Z2w