### PR TITLE
Fix cluster shutdown test timeout after go-supervisor v0.0.22 bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/robbyt/go-fsm/v2 v2.5.0
 	github.com/robbyt/go-loglater v0.2.0
 	github.com/robbyt/go-polyscript v0.8.0
-	github.com/robbyt/go-supervisor v0.0.21
+	github.com/robbyt/go-supervisor v0.0.22
 	github.com/robbyt/mcp-io v0.0.1
 	github.com/robbyt/protobaggins v0.2.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/robbyt/go-loglater v0.2.0 h1:9ci8njlgoiqqx+zfpr3F8uOBeORLSDDY+u+L0frC
 github.com/robbyt/go-loglater v0.2.0/go.mod h1:JTuKjCRdC6dsOs3k70zgJVkZVk+OT4cCsgUfw15B6dk=
 github.com/robbyt/go-polyscript v0.8.0 h1:mOZJfs7BWZI3wm2L01+pP1HffRHW/OZx1FAjRPhP61Y=
 github.com/robbyt/go-polyscript v0.8.0/go.mod h1:a4gqthRRwKM8XnY4K+TMLIL4mYtN3Ph3toONt894LLc=
-github.com/robbyt/go-supervisor v0.0.21 h1:EnfkcbS3vrJwgNg//4MmwWpuHSeqdUTa1OlkcjxMaUk=
-github.com/robbyt/go-supervisor v0.0.21/go.mod h1:TSmuA1z2zwlq6esWMjAxy5/VXuWAmR/4bYBOz9sQasg=
+github.com/robbyt/go-supervisor v0.0.22 h1:DZN7DL4MxHDZzU3ADRDTs90bPOMqpTYZUxjRQC1s9t0=
+github.com/robbyt/go-supervisor v0.0.22/go.mod h1:jRGGTG7uMqKcOr3zlgiFqYpxIxw+HSwo80JymtEStes=
 github.com/robbyt/mcp-io v0.0.1 h1:4c5mP6GiM1xtFiUztg6GqC0dx/HdQK4KLMZnAc38JC0=
 github.com/robbyt/mcp-io v0.0.1/go.mod h1:Mj4NIozkg6DfyRlgduknsKZr8LL/siy3phLeFDW8MxY=
 github.com/robbyt/protobaggins v0.2.0 h1:M5XaeEAXTrp9Jke6jpmy4HJAw3lhtVNflDKdWErkXUM=

--- a/internal/server/runnables/listeners/http/saga_test.go
+++ b/internal/server/runnables/listeners/http/saga_test.go
@@ -297,12 +297,14 @@ func TestRunner_WaitForClusterRunning(t *testing.T) {
 		err = runner.waitForClusterReady(ctx, 100*time.Millisecond)
 		require.NoError(t, err)
 
-		// Clean shutdown
+		// Clean shutdown. httpcluster's shutdown phase drains the config
+		// siphon with a ~100ms quiescence window before Run returns, so
+		// allow generous headroom beyond that to avoid racing the drain.
 		cancel()
 		select {
 		case err := <-clusterErr:
 			require.NoError(t, err)
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(2 * time.Second):
 			t.Fatal("cluster.Run should have returned after context cancellation")
 		}
 	})


### PR DESCRIPTION
go-supervisor v0.0.22 reworked httpcluster shutdown: Run now drives a
shutdown phase that drains the config siphon, and the drain waits for a
~100ms quiescence window before Run returns (bounded by the 5s default
shutdown timeout). As a result httpcluster.Run takes ~100ms to return
after context cancellation.

TestRunner_WaitForClusterRunning/cluster_becomes_ready only allowed
exactly 100ms for Run to return after cancel(), so it raced the drain
and failed. Widen the wait to 2s (matching the existing timeout used
elsewhere in this file). Production shutdown behavior is unaffected.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Fs8rbaVQJiLmDns1eA4Z2w